### PR TITLE
Semantic versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: ruby
+cache:
+  directories:
+    - $HOME/miniconda
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install xdotool
 install:
   - bash install.sh sunbeam anaconda_log.txt
 script: bash tests/test.sh
-#test
+

--- a/Snakefile
+++ b/Snakefile
@@ -9,6 +9,7 @@ import re
 import sys
 import yaml
 import configparser
+import warnings
 from pprint import pprint
 from pathlib import Path, PurePath
 
@@ -24,8 +25,18 @@ if not config:
                 "No config file specified. Run `sunbeam_init` to generate a "
                 "config file, and specify with --configfile")
 
-# ---- Substitute $HOME_DIR variable
-#varsub(config)
+# Check for major version compatibility
+pkg_major, cfg_major = check_compatibility(config)
+if pkg_major > cfg_major:
+        raise SystemExit(
+                "\nThis config file was created with an older version of Sunbeam"
+                " and may not be compatible. Create a new config file using"
+                "`sunbeam_init`\n")
+elif pkg_major < cfg_major:
+        raise SystemExit(
+                "\nThis config file was created with an older version of Sunbeam"
+                " and may not be compatible. Create a new config file using "
+                "`sunbeam_init`\n")
 
 # ---- Setting up config files and samples
 Cfg = check_config(config)
@@ -49,7 +60,6 @@ ANNOTATION_FP = output_subdir(Cfg, 'annotation')
 CLASSIFY_FP = output_subdir(Cfg, 'classify')
 MAPPING_FP = output_subdir(Cfg, 'mapping')
 
-#localrules: decontam
 
 # ---- Targets rules
 include: "rules/targets/targets.rules"

--- a/Snakefile
+++ b/Snakefile
@@ -9,7 +9,7 @@ import re
 import sys
 import yaml
 import configparser
-import warnings
+
 from pprint import pprint
 from pathlib import Path, PurePath
 

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -21,3 +21,4 @@ megahit
 cap3
 prodigal
 semantic_version
+setuptools_scm

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -20,3 +20,4 @@ igv=2.3.98
 megahit
 cap3
 prodigal
+semantic_version

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ from distutils.core import setup
 
 setup(
     name="sunbeam",
-    version="0.2.1",
+    use_scm_version = True,
+    setup_requires=['setuptools_scm'],
     packages=["sunbeamlib"],
     include_package_data=True,
     package_data={"sunbeamlib": ["sunbeamlib/data/*.yml"]},

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -4,14 +4,16 @@ __license__ = "GPL2+"
 import os
 import re
 import sys
-from setuptools_scm import get_version
+from pkg_resources import get_distribution
+#from setuptools_scm import get_version
 
 from semantic_version import Version
 from snakemake.utils import listfiles
 from snakemake.workflow import expand
 from Bio import SeqIO
 
-__version__ = str(Version.coerce(get_version()))
+__version__ = str(Version.coerce(get_distribution('sunbeam').version))
+# __version__ = str(Version.coerce(get_version()))
 
 def build_sample_list(data_fp, filename_fmt, samplelist_fp, excluded):
     if os.path.isfile(str(samplelist_fp)):

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -14,7 +14,6 @@ from snakemake.workflow import expand
 from Bio import SeqIO
 
 __version__ = str(Version.coerce(get_distribution('sunbeam').version))
-# __version__ = str(Version.coerce(get_version()))
 
 def build_sample_list(data_fp, filename_fmt, samplelist_fp, excluded):
     if os.path.isfile(str(samplelist_fp)):

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -4,12 +4,14 @@ __license__ = "GPL2+"
 import os
 import re
 import sys
+from setuptools_scm import get_version
 
+from semantic_version import Version
 from snakemake.utils import listfiles
 from snakemake.workflow import expand
 from Bio import SeqIO
 
-from .config import verify
+__version__ = str(Version.coerce(get_version()))
 
 def build_sample_list(data_fp, filename_fmt, samplelist_fp, excluded):
     if os.path.isfile(str(samplelist_fp)):
@@ -82,12 +84,12 @@ def _build_samples_from_file(data_fp, filename_fmt, samplelist_fp, excluded):
     return Samples
 
 def _check_sample_path(sample, fp):
-    try: verify(fp)
-    except ValueError:
+    path = Path(fp)
+    if not path.exists():
         sys.stderr.write(
             "Warning: original file for sample '{}' not found at {}\n".format(
                 sample, fp))
-    return fp
+    return path.resolve()
 
 def index_files(genome, index_fp):
     """

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -84,6 +84,8 @@ def _build_samples_from_file(data_fp, filename_fmt, samplelist_fp, excluded):
                     sample,
                     expand(str(data_fp/filename_fmt), sample=sample, rp=rp)[0])
             Samples[sample]['paired'] = True
+
+    print(Samples)
     return Samples
 
 def _check_sample_path(sample, fp):
@@ -92,7 +94,7 @@ def _check_sample_path(sample, fp):
         sys.stderr.write(
             "Warning: original file for sample '{}' not found at {}\n".format(
                 sample, fp))
-    return path.resolve()
+    return str(path.resolve())
 
 def index_files(genome, index_fp):
     """

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -4,8 +4,9 @@ __license__ = "GPL2+"
 import os
 import re
 import sys
+
+from pathlib import Path
 from pkg_resources import get_distribution
-#from setuptools_scm import get_version
 
 from semantic_version import Version
 from snakemake.utils import listfiles

--- a/sunbeamlib/config.py
+++ b/sunbeamlib/config.py
@@ -55,11 +55,7 @@ def check_compatibility(cfg):
     return (pkg_version.major, cfg_version.major)
     
 def check_config(cfg):
-    """
-    Validate the config file.
-    
-    Check version compatibility, resolve root in config file, then validate paths.
-    """
+    """Resolve root in config file, then validate paths."""
     
     if 'root' in cfg['all']:
         root = verify(cfg['all']['root'])

--- a/sunbeamlib/config.py
+++ b/sunbeamlib/config.py
@@ -1,9 +1,12 @@
 import sys
-import pkg_resources
 import collections
 from pathlib import Path
+from pkg_resources import get_distribution, resource_stream
 
+from semantic_version import Version
 import ruamel.yaml
+from sunbeamlib import __version__
+
 
 def makepath(path):
     return Path(path).expanduser()
@@ -43,9 +46,21 @@ def validate_paths(cfg, root):
         new_cfg[k] = v
     return new_cfg
 
+def check_compatibility(cfg):
+    """Returns the major version numbers from the package and config file, respectively"""
 
+    cfg_version = Version(cfg['all'].get('version', '0.0.0'))
+    pkg_version = Version(__version__)
+
+    return (pkg_version.major, cfg_version.major)
+    
 def check_config(cfg):
-    """Resolve root in config file, then validate paths."""
+    """
+    Validate the config file.
+    
+    Check version compatibility, resolve root in config file, then validate paths.
+    """
+    
     if 'root' in cfg['all']:
         root = verify(cfg['all']['root'])
     else:
@@ -91,18 +106,23 @@ def update(config_str, new):
     config = _update_dict(config, new)
     return config
 
-def new(conda_fp, project_fp, template=None):
+def new(
+        conda_fp, project_fp,
+        version=__version__,
+        template=None):
     if template:
         config = template.read()
     else:
-        config = pkg_resources.resource_stream(
+        config = resource_stream(
             "sunbeamlib", "data/default_config.yml").read().decode()
     return config.format(
-        CONDA_FP=conda_fp, PROJECT_FP=project_fp)
+        CONDA_FP=conda_fp,
+        PROJECT_FP=project_fp,
+        SB_VERSION=version)
 
 def load_defaults(default_name):
     return ruamel.yaml.safe_load(
-        pkg_resources.resource_stream(
+        resource_stream(
             "sunbeamlib", "data/{}.yml".format(default_name)
         ).read().decode())
     

--- a/sunbeamlib/config.py
+++ b/sunbeamlib/config.py
@@ -1,7 +1,7 @@
 import sys
 import collections
 from pathlib import Path
-from pkg_resources import get_distribution, resource_stream
+from pkg_resources import resource_stream
 
 from semantic_version import Version
 import ruamel.yaml

--- a/sunbeamlib/data/default_config.yml
+++ b/sunbeamlib/data/default_config.yml
@@ -28,7 +28,7 @@ all:
   samplelist_fp: ""
   filename_fmt: "{{sample}}_{{rp}}.fastq.gz"
   exclude: []
-
+  version: "{SB_VERSION}"
 
 # Quality control
 qc:

--- a/sunbeamlib/initialize.py
+++ b/sunbeamlib/initialize.py
@@ -5,7 +5,7 @@ import ruamel.yaml
 
 from pathlib import Path
 
-import sunbeamlib
+from sunbeamlib import config
 
 def _find_conda_fp():
     """Try to detect conda install in the path."""
@@ -48,11 +48,11 @@ def main():
         args.conda_fp = args.conda_fp.absolute()
 
     
-    config = sunbeamlib.config.new(
-        args.conda_fp, args.project_fp, args.template)
+    cfg = config.new(
+        conda_fp=args.conda_fp, project_fp=args.project_fp, template=args.template)
 
     if args.defaults:
-        defaults = sunbeamlib.config.load_defaults(args.defaults)
-        config = sunbeamlib.config.update(config, defaults)
+        defaults = config.load_defaults(args.defaults)
+        cfg = config.update(cfg, defaults)
         
-    sunbeamlib.config.dump(config)
+    config.dump(cfg)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -133,3 +133,11 @@ snakemake --configfile=$TEMPDIR/tmp_config_barcode.yml all_decontam
 }
 
 test_barcode_file
+
+# Test for version check
+function test_version_check {
+    sunbeam_mod_config --config $TEMPDIR/tmp_config.yml --mod_str 'all: {version: 9999.9.9}' > $TEMPDIR/too_high_config.yml
+    snakemake --configfile $TEMPDIR/too_high_config.yml && exit 1
+}
+
+test_version_check

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3,7 +3,6 @@
 set -e # Stop on errors
 set -x # Display all commands
 
-echo "Testing"
 
 # Ensure we can activate the environment
 export PATH=$PATH:$HOME/miniconda3/bin
@@ -137,7 +136,10 @@ test_barcode_file
 # Test for version check
 function test_version_check {
     sunbeam_mod_config --config $TEMPDIR/tmp_config.yml --mod_str 'all: {version: 9999.9.9}' > $TEMPDIR/too_high_config.yml
-    snakemake --configfile $TEMPDIR/too_high_config.yml && exit 1
+    # this should produce a nonzero exit code and fail if it does not
+    if snakemake --configfile $TEMPDIR/too_high_config.yml; then
+	exit 1
+    fi
 }
 
 test_version_check


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [x] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

This update now versions `sunbeamlib` according to the git tags on each release, and `sunbeam_init` writes that into config files. When calling `snakemake`, a check is performed to ensure the major versions of the config file and `sunbeamlib` are the same. To get around this check, a user can manually edit the version number in the config file (for debugging).