### PR TITLE
Test.sh tests installation; update to Snakemake dep. version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 install:
   - bash tests/test.sh
-test:
+script:
   - echo "Done"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: ruby
 cache:
   directories:
     - $HOME/miniconda
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install xdotool
 install:
-  - bash install.sh sunbeam anaconda_log.txt
-script: bash tests/test.sh
+  - bash tests/test.sh
+
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
-cache:
-  directories:
-    - $HOME/miniconda
 install:
   - bash tests/test.sh
-
+test:
+  - echo "Done"
 

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -1,4 +1,4 @@
-snakemake=3.13.0
+snakemake
 ruamel.yaml
 biopython
 trimmomatic

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,6 @@ conda env list | cut -f1 -d' ' | grep -Fxq $SUNBEAM_ENV_NAME || {
     conda create --name=$SUNBEAM_ENV_NAME --file=conda-requirements.txt --yes >> $OUTPUT
     source activate $SUNBEAM_ENV_NAME
     pip install --editable . >> $OUTPUT
-    pip install git+https://github.com/eclarke/decontam.git >> $OUTPUT
     echo "Sunbeam successfully installed.";
 }
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -17,8 +17,12 @@ else
     TEMPDIR=`readlink -f $1`
 fi
 
+# Install sunbeam into temporary environment
+SUNBEAM_ENV="sunbeam-`basename $TEMPDIR`"
+bash install.sh $SUNBEAM_ENV
+
 # Activate the sunbeam environment
-source activate sunbeam
+source activate $SUNBEAM_ENV
 command -v snakemake
 
 mkdir -p $TEMPDIR/data_files
@@ -28,7 +32,8 @@ function cleanup {
     # (must be careful with rm -rf and variables)
     # Keep retcode from any previous command
     RETCODE=$?
-    echo "Exiting with return code $RETCODE"
+    echo "Removing files and exiting with return code $RETCODE"
+    source deactivate && conda env remove -yn $SUNBEAM_ENV
     [ -z ${TEMPDIR+x} ] || rm -rf "$TEMPDIR"; exit $RETCODE
 }
 


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

## Testing changes

This now tests the install process as well as the workflow by installing sunbeam into a new conda env (named `sunbeam-$TMPDIR` based on the temporary testing directory) that gets removed after successful testing.

## Bugfixes

- Fixes #77 