### PR TITLE
integrate low-complexity masking using komplexity

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -17,3 +17,4 @@ prodigal
 semantic_version
 setuptools_scm
 bbmap
+komplexity

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -168,16 +168,17 @@ qc
   using cutadapt. Replace with "" to skip.
 * ``rev_adaptors``: (cutadapt) custom reverse adaptor sequences to remove
   using cutadapt. Replace with "" to skip.
+* ``mask_low_complexity``: [true/false] mask low-complexity sequences with Ns
+* ``kz_threshold``: a value between 0 and 1 to determine the low-complexity boundary (1 is most stringent). Ignored if not masking low-complexity sequences.
+* ``kz_window``: window size to use (in bp) for local complexity
+  assessment. Ignored if not masking low-complexity sequences.
 * ``pct_id``: (decontaminate) minimum percent identity to host genome to
   consider match
 * ``frac``: (decontaminate) minimum fraction of the read that must align to
   consider match
-* ``keep_sam``: (decontaminate) keep SAM file of host read alignment for
-  debuggging
-* ``method``: (decontaminate) use either BWA or BowTie for alignment
-* ``human_genome_fp``: The path to the host genome for host read
-  removal. Despite the name, this doesn't have to be a human genome.
-* ``phix_genome_fp``: The path to the PhiX genome for PhiX removal.
+* ``host_fp``: the path to the folder with host/contaminant genomes (ending in
+  *.fasta)
+
 
 classify
 ++++++++

--- a/rules/qc/decontaminate.rules
+++ b/rules/qc/decontaminate.rules
@@ -19,8 +19,8 @@ rule build_host_index:
 
 rule align_to_host:
     input:
-        r1 = str(QC_FP/'paired'/'{sample}_R1.fastq.gz'),
-        r2 = str(QC_FP/'paired'/'{sample}_R2.fastq.gz'),
+        r1 = str(QC_FP/'masked'/'{sample}_R1.fastq.gz'),
+        r2 = str(QC_FP/'masked'/'{sample}_R2.fastq.gz'),
         index = str(Cfg['qc']['host_fp']/'{host}.fasta.amb')
     output:
         temp(str(QC_FP/'decontam'/'intermediates'/'{host}'/'{sample}.bam'))

--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -82,3 +82,18 @@ rule fastqc:
             str(QC_FP/'paired'/'{{sample}}_{rp}_fastqc/fastqc_data.txt'),
             rp=['R1', 'R2'])
     shell: "fastqc {input.r1} {input.r2} -extract"
+
+rule mask_low_complexity:
+    input:
+        str(QC_FP/'paired'/'{sample}_{rp}.fastq.gz')
+    output:
+        str(QC_FP/'masked'/'{sample}_{rp}.fastq.gz')
+    run:
+        if Cfg['qc']['mask_low_complexity']:
+            shell("""
+            kz --mask -t {Cfg[qc][kz_threshold]} -w {Cfg[qc][kz_window]} \
+            < <(gzip -cd {input}) | gzip -c > {output}
+            """)
+        else:
+            shell("ln -s {input} {output}")
+            

--- a/sunbeamlib/data/default_config.yml
+++ b/sunbeamlib/data/default_config.yml
@@ -44,6 +44,10 @@ qc:
   # Cutadapt
   fwd_adapters: ['GTTTCCCAGTCACGATC', 'GTTTCCCAGTCACGATCNNNNNNNNNGTTTCCCAGTCACGATC']
   rev_adapters: ['GTTTCCCAGTCACGATC', 'GTTTCCCAGTCACGATCNNNNNNNNNGTTTCCCAGTCACGATC']
+  # Komplexity
+  mask_low_complexity: true
+  kz_threshold: 0.55
+  kz_window: 32
   # Decontam.py
   pct_id: 0.5
   frac: 0.6

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -48,7 +48,7 @@ cp -r indexes $TEMPDIR
 cp -r raw $TEMPDIR
 cp -r truncated_taxonomy $TEMPDIR
 cp seqid2taxid.map $TEMPDIR
-mkdir $TEMPDIR/hosts
+mkdir -p $TEMPDIR/hosts
 cp indexes/*.fasta $TEMPDIR/hosts
 
 python generate_dummy_data.py $TEMPDIR


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [x] If this adds a new output file, I have added a check to tests/targets.txt
* [x] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [x] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

## Pipeline changes

This incorporates [komplexity](https://github.com/eclarke/komplexity) to mask low-complexity sequences before host read removal. I've chosen to use masking rather than read removal for simplicity and because that's what we've been testing for the manuscript. 

## Config file changes

- `mask_low_complexity`: can be either true or false. If false, masking is skipped.
- `kz_threshold`: threshold between 0-1 for komplexity (kz)
- `kz_window`: window size for komplexity, in bp

## Thanks

With many thanks to @louiejtaylor for packaging komplexity for conda.