### PR TITLE
use rbt for fastq filtering

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,5 +22,5 @@ dependencies:
   - semantic_version
   - setuptools_scm
   - komplexity
-  - bbmap
+  - rust-bio-tools
 

--- a/rules/qc/decontaminate.rules
+++ b/rules/qc/decontaminate.rules
@@ -83,10 +83,8 @@ rule filter_reads:
         host = int(subprocess.getoutput("cat {} | wc -l".format(input.hostreads)).strip())
         nonhost = int(original-host)
         shell("""
-        filterbyname.sh \
-        in={input.r1} in2={input.r2} \
-        out={output.r1} out2={output.r2} \
-        names={input.hostreads}
+        gzip -dc {input.r1} | rbt fastq-filter {input.hostreads} | gzip > {output.r1}
+        gzip -dc {input.r2} | rbt fastq-filter {input.hostreads} | gzip > {output.r2}
         """)
         with open(output.log, 'w') as log:
             log.write("host\tnonhost\n")


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [x] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

Removes dependency on bbtools in favor of rust-bio-tools for fastq filtering.