### PR TITLE
negate default 50k max seq length for contigs

### DIFF
--- a/rules/assembly/assembly.rules
+++ b/rules/assembly/assembly.rules
@@ -55,6 +55,7 @@ rule final_filter:
         then
             vsearch --sortbylength {input} \
             --minseqlength {params.len} \
+            --maxseqlength -1 \
             --output {input}.{params.len}f &> {log} && \
             cp {input}.{params.len}f {output}
         else


### PR DESCRIPTION
* [ ] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
