### PR TITLE
decontam counts for each host 

### DIFF
--- a/rules/qc/decontaminate.rules
+++ b/rules/qc/decontaminate.rules
@@ -1,5 +1,6 @@
 import subprocess
 from sunbeamlib.decontam import get_mapped_reads
+from collections import OrderedDict
 
 rule all_decontam:
     input:
@@ -76,7 +77,8 @@ rule aggregate_reads:
 rule filter_reads:
     input:
         hostreads = str(QC_FP/'decontam'/'intermediates'/'{sample}_hostreads.ids'),
-        reads = str(QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz')
+        reads = str(QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz'),
+        hostids = expand(str(QC_FP/'decontam'/'intermediates'/'{host}'/'{{sample}}.ids'), host=HostGenomes.keys())
     output:
         reads = str(QC_FP/'decontam'/'{sample}_{rp}.fastq.gz'),
         log = str(QC_FP/'log'/'decontam'/'{sample}_{rp}.txt')
@@ -91,6 +93,13 @@ rule filter_reads:
         rbt fastq-filter {input.hostreads} | \
         gzip > {output.reads}
         """)
+        
+        hostdict = OrderedDict()
+        for hostid in input.hostids:
+            hostname = os.path.basename(os.path.dirname(hostid))
+            hostcts = int(subprocess.getoutput("cat {} | wc -l".format(hostid)).strip())
+            hostdict[hostname] = hostcts
+        
         with open(output.log, 'w') as log:
-            log.write("host\tnonhost\n")
-            log.write("{}\t{}\n".format(host, nonhost))
+            log.write("{}\n".format("\t".join(list(hostdict.keys()) + ["host","nonhost"] )))
+            log.write("{}\n".format("\t".join( map(str, list(hostdict.values()) + [host, nonhost]) )))

--- a/rules/reports/reports.rules
+++ b/rules/reports/reports.rules
@@ -4,6 +4,7 @@
 
 import pandas
 from io import StringIO
+from collections import OrderedDict
 
 rule all_reports:
     input:
@@ -14,19 +15,19 @@ def parse_trim_summary_paired(f):
         if line.startswith('Input Read'):
             vals = re.findall('\D+\: (\d+)', line)
             keys = ('input', 'both_kept','fwd_only','rev_only','dropped')
-            return(dict(zip(keys, vals)))
+            return(OrderedDict(zip(keys, vals)))
 
 def parse_trim_summary_single(f):
     for line in f:
         if line.startswith('Input Read'):
             vals = re.findall('\D+\: (\d+)', line)
             keys = ('input', 'kept', 'dropped')
-            return(dict(zip(keys, vals)))
+            return(OrderedDict(zip(keys, vals)))
 
 def parse_decontam_log(f):
-    f.readline()
-    (host, nonhost) = f.readline().split()
-    return {'host':host, 'nonhost':nonhost}
+    keys = f.readline().rstrip().split('\t')
+    vals = f.readline().rstrip().split('\t')
+    return(OrderedDict(zip(keys,vals)))
 
 def summarize_qual_decontam(tfile, dfile):
     """Return a dataframe for summary information for trimmomatic and decontam rule"""
@@ -42,9 +43,8 @@ def summarize_qual_decontam(tfile, dfile):
             decontam_data = parse_decontam_log(jf)
     sys.stderr.write("trim data: {}\n".format(trim_data))
     sys.stderr.write("decontam data: {}\n".format(decontam_data))
-    merged_dict = {**trim_data, **decontam_data}
-    # todo: use yield for pandas DataFrame
-    return(pandas.DataFrame(merged_dict, index=[tname]))
+    print(OrderedDict(trim_data, **(decontam_data)))
+    return(pandas.DataFrame(OrderedDict(trim_data, **(decontam_data)), index=[tname]))
 
 rule preprocess_report:
     """Combines the information from multiple preprocessing steps"""
@@ -58,7 +58,8 @@ rule preprocess_report:
     output:
         str(QC_FP/'reports'/'preprocess_summary.tsv')
     run:
-        summary_list = [summarize_qual_decontam(q, d) for q, d in zip(input.trim_files, input.decontam_files)]
+        summary_list = [summarize_qual_decontam(q, d) for q, d in 
+                       zip(input.trim_files, input.decontam_files)]
         reports = pandas.concat(summary_list)
         reports.to_csv(output[0], sep='\t', index_label='Samples')
 

--- a/rules/reports/reports.rules
+++ b/rules/reports/reports.rules
@@ -43,7 +43,6 @@ def summarize_qual_decontam(tfile, dfile):
             decontam_data = parse_decontam_log(jf)
     sys.stderr.write("trim data: {}\n".format(trim_data))
     sys.stderr.write("decontam data: {}\n".format(decontam_data))
-    print(OrderedDict(trim_data, **(decontam_data)))
     return(pandas.DataFrame(OrderedDict(trim_data, **(decontam_data)), index=[tname]))
 
 rule preprocess_report:


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
