### PR TITLE
Bugfixes for `sunbeam run`

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -57,7 +57,6 @@ Cfg = check_config(config)
 Blastdbs = process_databases(Cfg['blastdbs'])
 Samples = build_sample_list(Cfg['all']['samplelist_fp'], Cfg['all']['paired_end'])
 Pairs = ['1', '2'] if Cfg['all']['paired_end'] else ['1']
-print(Samples)
 
 # Collect host (contaminant) genomes
 sys.stderr.write("Collecting host/contaminant genomes... ")

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -54,34 +54,42 @@ def guess_format_string(fnames, paired_end=True, split_pattern="([_\.])"):
     """
     
     if isinstance(fnames, str):
-        raise ValueError("need a list of filenames, not a string")
+        raise SampleFormatError("need a list of filenames, not a string")
     if len(fnames) == 1:
-        raise ValueError("need a list of filenames, not just one")
+        raise SampleFormatError("need a list of filenames, not just one")
     if len(set(fnames)) == 1:
-        raise ValueError("all filenames are the same")
+        raise SampleFormatError("all filenames are the same")
     
     splits = [re.split(split_pattern, fname) for fname in fnames]
 
     if len(set([len(p) for p in splits])) > 1:
-        raise ValueError("files have inconsistent numbers of _ or . characters")
+        raise SampleFormatError("files have inconsistent numbers of _ or . characters")
 
     elements = []
     variant_idx = []
 
     for i, parts in enumerate(zip(*splits)):
+        # A special case when paired-end and only two files:
+        # invariant regions may be sample names (since only one sample)
+        if len(parts) == 2 and paired_end:
+            potential_single_sample = True
+            
         items = set(parts)
         # If they're all the same, it's a common part; so add it to the element
         # list unchanged
-        if len(items) == 1:
+        if items.issubset({"fastq", ".", "_", "gz", "fq"}):
+            elements.append(parts[0])
+        elif len(items) == 1 and not potential_single_sample:
             elements.append(parts[0])
         else:
             if paired_end:
                 # If all the items in a split end with 1 or 2, and only have
                 # one char preceding that that's the same among all items,
-                # then it's like a read-pair identifier.
+                # OR all the items are 1 or 2 and the only things in a split,
+                # then it's likely a read-pair identifier.
                 if set(_[-1] for _ in items) == {'1', '2'}:
                     prefixes = set(_[:-1] for _ in items)
-                    if len(prefixes) == 1 and all(len(p) == 1 for p in prefixes):
+                    if prefixes == {''} or (len(prefixes) == 1 and all(len(p) == 1 for p in prefixes)):
                         prefix = parts[0][:-1]
                         elements.append(prefix)
                         elements.append("{rp}")
@@ -95,7 +103,11 @@ def guess_format_string(fnames, paired_end=True, split_pattern="([_\.])"):
     elements[_min:_max+1] = ["{sample}"]
     return "".join(elements)
 
+class MissingMatePairError(Exception):
+    pass
 
+class SampleFormatError(Exception):
+    pass
 
 def _verify_path(fp):
     if not fp:

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -68,12 +68,11 @@ def guess_format_string(fnames, paired_end=True, split_pattern="([_\.])"):
     elements = []
     variant_idx = []
 
+    # A special case when paired-end and only two files:
+    # invariant regions may be sample names (since only one sample)
+    potential_single_sample = len(fnames) == 1 and paired_end
+
     for i, parts in enumerate(zip(*splits)):
-        # A special case when paired-end and only two files:
-        # invariant regions may be sample names (since only one sample)
-        if len(parts) == 2 and paired_end:
-            potential_single_sample = True
-            
         items = set(parts)
         # If they're all the same, it's a common part; so add it to the element
         # list unchanged

--- a/sunbeamlib/scripts/init.py
+++ b/sunbeamlib/scripts/init.py
@@ -4,7 +4,7 @@ import argparse
 import ruamel.yaml
 from pathlib import Path
 
-from .list_samples import build_sample_list
+from .list_samples import build_sample_list, MissingMatePairError, SampleFormatError
 from sunbeamlib import config
     
 def main(argv=sys.argv):
@@ -94,12 +94,16 @@ def main(argv=sys.argv):
                     is_single_end = args.single_end)
                 sys.stderr.write(
                     "New sample list written to {}\n".format(samplelist_file))
-        except ValueError as e:
+        except SampleFormatError as e:
             raise SystemExit(
-                "Error: could not create sample list (reason: {}). Provide a "
-                "format string using --format, use `sunbeam list_samples` or "
-                "create manually (see user guide).".format(e))
-
+                "Error: could not create sample list. Specify correct sample filename"
+                " format using --format.\n  Reason: {}".format(e))
+        except MissingMatePairError as e:
+            raise SystemExit(
+                "Error: assuming paired-end reads, but could not find mates. Specify "
+                "--single-end if not paired-end, or provide sample name format "
+                "using --format."
+                "\n  Reason: {}".format(e))
         
 def check_existing(path, force=False):
     if path.is_dir():

--- a/sunbeamlib/scripts/run.py
+++ b/sunbeamlib/scripts/run.py
@@ -33,9 +33,10 @@ def main(argv=sys.argv):
                 args.sunbeam_dir))
         sys.exit(1)
         
-    snakemake_args = ['--snakefile', snakefile] + remaining
-    
-    cmd = subprocess.run(['snakemake'] + snakemake_args)
+    snakemake_args = ['snakemake', '--snakefile', str(snakefile)] + remaining
+    print("Running: "+" ".join(snakemake_args))
+
+    cmd = subprocess.run(snakemake_args)
     
     sys.exit(cmd.returncode)
     


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

This should fix #139, an edge case that may occur with only one pair of read files, and potentially another underlying issue converting PosixPath to str implicitly (maybe only on Python 3.5?)