### PR TITLE
Sample name guessing

### DIFF
--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -94,7 +94,12 @@ def guess_format_string(fnames, paired_end=True, split_pattern="([_\.])"):
                 # then it's likely a read-pair identifier.
                 if set(_[-1] for _ in items) == {'1', '2'}:
                     prefixes = set(_[:-1] for _ in items)
-                    if prefixes == {''} or (len(prefixes) == 1 and all(len(p) == 1 for p in prefixes)):
+                    print(prefixes)
+                    NO_PREFIX = prefixes == {''}
+                    ALL_SAME_PREFIX = len(prefixes) == 1
+                    ONE_CHAR_PREFIX = all(len(p) == 1 for p in prefixes)
+                    I_OR_R_PREFIX = prefixes == {'I', 'R'}
+                    if NO_PREFIX or (ALL_SAME_PREFIX and ONE_CHAR_PREFIX) or I_OR_R_PREFIX:
                         prefix = parts[0][:-1]
                         elements.append("{rp}")
                         elements.append(prefix)

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -61,7 +61,6 @@ def guess_format_string(fnames, paired_end=True, split_pattern="([_\.])"):
         raise SampleFormatError("no files in directory!")
     
     splits = [list(reversed(re.split(split_pattern, fname))) for fname in fnames]
-    print(splits)
 
     if len(fnames) == 1:
         sys.stderr.write("Only one sample found; defaulting to {sample}.fastq.gz\n")
@@ -81,7 +80,7 @@ def guess_format_string(fnames, paired_end=True, split_pattern="([_\.])"):
         items = set(parts)
         # If they're all the same, it's a common part; so add it to the element
         # list unchanged
-        print(items)
+
         if items.issubset({"fastq", ".", "_", "gz", "fq"}):
             elements.append(parts[0])
         elif len(items) == 1 and not potential_single_sample:
@@ -94,7 +93,6 @@ def guess_format_string(fnames, paired_end=True, split_pattern="([_\.])"):
                 # then it's likely a read-pair identifier.
                 if set(_[-1] for _ in items) == {'1', '2'}:
                     prefixes = set(_[:-1] for _ in items)
-                    print(prefixes)
                     NO_PREFIX = prefixes == {''}
                     ALL_SAME_PREFIX = len(prefixes) == 1
                     ONE_CHAR_PREFIX = all(len(p) == 1 for p in prefixes)
@@ -106,13 +104,14 @@ def guess_format_string(fnames, paired_end=True, split_pattern="([_\.])"):
                         continue
             variant_idx.append(i)                        
             elements.append("{sample}")
-    print(elements)
-    print(variant_idx)
     # Combine multiple variant elements
-    _min = min(variant_idx)
-    _max = max(variant_idx)
-    elements[_min+1:_max+2] = ["{sample}"]
-    return "".join(reversed(elements))
+    if len(variant_idx) > 0:
+        _min = min(variant_idx)
+        _max = max(variant_idx)
+        elements[_min+1:_max+2] = ["{sample}"]
+        return "".join(reversed(elements))
+    else:
+        raise SampleFormatError("No variable regions identified")
 
 class MissingMatePairError(Exception):
     pass

--- a/sunbeamlib/__init__.py
+++ b/sunbeamlib/__init__.py
@@ -98,7 +98,10 @@ def guess_format_string(fnames, paired_end=True, split_pattern="([_\.])"):
                     ONE_CHAR_PREFIX = all(len(p) == 1 for p in prefixes)
                     I_OR_R_PREFIX = prefixes == {'I', 'R'}
                     if NO_PREFIX or (ALL_SAME_PREFIX and ONE_CHAR_PREFIX) or I_OR_R_PREFIX:
-                        prefix = parts[0][:-1]
+                        if I_OR_R_PREFIX:
+                            prefix = 'R'
+                        else:
+                            prefix = parts[0][:-1]
                         elements.append("{rp}")
                         elements.append(prefix)
                         continue

--- a/sunbeamlib/scripts/list_samples.py
+++ b/sunbeamlib/scripts/list_samples.py
@@ -35,8 +35,8 @@ def main(argv=sys.argv):
             " format using --format. \n\tReason: {}".format(e))
     except MissingMatePairError as e:
         raise SystemExit(
-            "Detected paired-end reads, but could not find mates. Specify "
-            "--single-end if not paired-end, or provide sample name format "
+            "Assuming paired-end reads, but could not find mates. Specify "
+            "--single_end if not paired-end, or provide sample name format "
             "using --format."
             "\n\tReason: {}".format(e))
 
@@ -65,7 +65,7 @@ def build_sample_list(data_fp, format_str, output_file, is_single_end):
                     ", ".join(no_match)))
 
     if len(samples) == 0:
-        raise ("no samples matching the given format found.")
+        raise SampleFormatError("no samples matching the given format found.")
 
     sys.stderr.write("Found {} samples in {}.\n".format(len(samples), data_fp))
     fieldnames = ["sample", "1", "2"]

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -71,3 +71,41 @@ function test_pair_concordance {
 	fi
     done
 }
+
+# Test that we can guess a variety of sample names correctly
+# Correct behavior for only two samples
+function test_guess_with_two_samples {
+    mkdir -p $TEMPDIR/only_two_samples
+    touch $TEMPDIR/only_two_samples/sample_1.fastq.gz
+    touch $TEMPDIR/only_two_samples/sample_2.fastq.gz
+    sunbeam list_samples $TEMPDIR/only_two_samples 2> >(tee out.txt >&2)
+    grep '{sample}_{rp}.fastq.gz' out.txt
+}
+
+# Correct behavior for samples with inconsistent _ or .
+function test_guess_with_inconsistent_samples {
+    mkdir -p $TEMPDIR/inconsistent_samples
+    touch $TEMPDIR/inconsistent_samples/asdf_123_R1.fastq.gz
+    touch $TEMPDIR/inconsistent_samples/asdf_123_R2.fastq.gz
+    touch $TEMPDIR/inconsistent_samples/asddf_R1.fastq.gz
+    touch $TEMPDIR/inconsistent_samples/asddf_R2.fastq.gz
+    sunbeam list_samples $TEMPDIR/inconsistent_samples 2> >(tee out.txt >&2)
+    grep '{sample}_R{rp}.fastq.gz' out.txt
+    rm -r $TEMPDIR/inconsistent_samples
+}
+
+# Correct behavior for folders that still have index files
+function test_guess_with_index_files_present {
+    mkdir -p $TEMPDIR/idx_files_present
+    touch $TEMPDIR/idx_files_present/asdf_123_R1.fastq.gz
+    touch $TEMPDIR/idx_files_present/asdf_123_R2.fastq.gz
+    touch $TEMPDIR/idx_files_present/asddf_R1.fastq.gz
+    touch $TEMPDIR/idx_files_present/asddf_R2.fastq.gz
+    touch $TEMPDIR/idx_files_present/asdf_123_I1.fastq.gz
+    touch $TEMPDIR/idx_files_present/asdf_123_I2.fastq.gz
+    touch $TEMPDIR/idx_files_present/asddf_I1.fastq.gz
+    touch $TEMPDIR/idx_files_present/asddf_I2.fastq.gz
+    sunbeam list_samples $TEMPDIR/idx_files_present 2> >(tee out.txt >&2)
+    grep '{sample}_R{rp}.fastq.gz' out.txt
+#    rm -r $TEMPDIR/idx_files_present
+}


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [x] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

Bugfixes related to sample name guessing. In particular:

- can now work with sample names that have consistent ends (like `_001.fastq.gz`) but inconsistent numbers of underscores preceding the end (like `extractionblank_S01_L001_R1_001.fastq.gz` vs `S_123_S01_L001_R1_001.fastq.gz`)
- now understands and ignores index files (I1 and I2) in the data directory
- added new tests for sample parsing edge cases like these

Fixes #146.