### PR TITLE
Bugfixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6
+      - image: circleci/python:3.5
 
     steps:
       - checkout

--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,10 @@ To get started, see our [documentation](http://sunbeam.readthedocs.io)!
 
 ### Changelog:
 
+#### v1.2.1 (May 24, 2018)
+
+ - Minor bugfixes
+
 #### v1.2.0 (May 2, 2018)
 
  - Low-complexity reads are now removed by default rather than masked

--- a/rules/reports/reports.rules
+++ b/rules/reports/reports.rules
@@ -3,7 +3,7 @@
 # ReportGeneration rules
 
 import pandas
-from io import StringIO
+
 from collections import OrderedDict
 from sunbeamlib import reports
 
@@ -24,10 +24,12 @@ rule preprocess_report:
     output:
         str(QC_FP/'reports'/'preprocess_summary.tsv')
     run:
-        summary_list = [reports.summarize_qual_decontam(q, d) for q, d in 
-                       zip(input.trim_files, input.decontam_files)]
-        reports = pandas.concat(summary_list)
-        reports.to_csv(output[0], sep='\t', index_label='Samples')
+        paired_end = Cfg['all']['paired_end']
+        summary_list = [
+            reports.summarize_qual_decontam(q, d, paired_end) for q, d in 
+            zip(input.trim_files, input.decontam_files)]
+        _reports = pandas.concat(summary_list)
+        _reports.to_csv(output[0], sep='\t', index_label='Samples')
 
 
 rule fastqc_report:

--- a/rules/reports/reports.rules
+++ b/rules/reports/reports.rules
@@ -5,45 +5,12 @@
 import pandas
 from io import StringIO
 from collections import OrderedDict
+from sunbeamlib import reports
 
 rule all_reports:
     input:
         TARGET_REPORT
 
-def parse_trim_summary_paired(f):
-    for line in f.readlines():
-        if line.startswith('Input Read'):
-            vals = re.findall('\D+\: (\d+)', line)
-            keys = ('input', 'both_kept','fwd_only','rev_only','dropped')
-            return(OrderedDict(zip(keys, vals)))
-
-def parse_trim_summary_single(f):
-    for line in f:
-        if line.startswith('Input Read'):
-            vals = re.findall('\D+\: (\d+)', line)
-            keys = ('input', 'kept', 'dropped')
-            return(OrderedDict(zip(keys, vals)))
-
-def parse_decontam_log(f):
-    keys = f.readline().rstrip().split('\t')
-    vals = f.readline().rstrip().split('\t')
-    return(OrderedDict(zip(keys,vals)))
-
-def summarize_qual_decontam(tfile, dfile):
-    """Return a dataframe for summary information for trimmomatic and decontam rule"""
-    tname = os.path.basename(tfile).split('.out')[0]
-    dname = os.path.basename(dfile).split('.txt')[0]
-    with open(tfile) as tf:
-        with open(dfile) as jf:
-            if Cfg['all']['paired_end']:
-                trim_data = parse_trim_summary_paired(tf)
-            else:
-                trim_data = parse_trim_summary_single(tf)
-                
-            decontam_data = parse_decontam_log(jf)
-    sys.stderr.write("trim data: {}\n".format(trim_data))
-    sys.stderr.write("decontam data: {}\n".format(decontam_data))
-    return(pandas.DataFrame(OrderedDict(trim_data, **(decontam_data)), index=[tname]))
 
 rule preprocess_report:
     """Combines the information from multiple preprocessing steps"""
@@ -57,25 +24,11 @@ rule preprocess_report:
     output:
         str(QC_FP/'reports'/'preprocess_summary.tsv')
     run:
-        summary_list = [summarize_qual_decontam(q, d) for q, d in 
+        summary_list = [reports.summarize_qual_decontam(q, d) for q, d in 
                        zip(input.trim_files, input.decontam_files)]
         reports = pandas.concat(summary_list)
         reports.to_csv(output[0], sep='\t', index_label='Samples')
 
-def parse_fastqc_quality(filename):
-    with open(filename) as f:
-        report = f.read()
-    tableString = re.search(
-        '\>\>Per base sequence quality.*?\n(.*?)\n\>\>END_MODULE',
-        report, re.DOTALL).group(1)
-
-    f_s = StringIO(tableString)
-    df = pandas.read_csv(
-        f_s, sep='\t', usecols=['#Base', 'Mean'], index_col='#Base')
-    sample_name = os.path.basename(filename.split('_fastqc')[0])
-    df.columns=[sample_name]
-    f_s.close()
-    return(df)
 
 rule fastqc_report:
     """ make fastqc reports """
@@ -86,6 +39,6 @@ rule fastqc_report:
     output:
         str(QC_FP/'reports'/'fastqc_quality.tsv')
     run:
-        quality_list = [parse_fastqc_quality(file) for file in input.files]
+        quality_list = [reports.parse_fastqc_quality(file) for file in input.files]
         quality_table = pandas.concat(quality_list, axis=1).transpose()
         quality_table.to_csv(output[0],sep="\t",index_label="Samples")

--- a/sunbeamlib/reports.py
+++ b/sunbeamlib/reports.py
@@ -1,8 +1,13 @@
 import warnings
 warnings.filterwarnings('ignore', '.*experimental.*')
 from pathlib import Path
-from collections import Counter
+from collections import Counter, OrderedDict
+import re
+import os
+import sys
 
+import pandas
+from io import StringIO
 from Bio import SeqIO
 from Bio import SearchIO
 from Bio.SeqRecord import SeqRecord
@@ -50,13 +55,13 @@ def parse_decontam_log(f):
     vals = f.readline().rstrip().split('\t')
     return(OrderedDict(zip(keys,vals)))
 
-def summarize_qual_decontam(tfile, dfile):
+def summarize_qual_decontam(tfile, dfile, paired_end):
     """Return a dataframe for summary information for trimmomatic and decontam rule"""
     tname = os.path.basename(tfile).split('.out')[0]
     dname = os.path.basename(dfile).split('.txt')[0]
     with open(tfile) as tf:
         with open(dfile) as jf:
-            if Cfg['all']['paired_end']:
+            if paired_end:
                 trim_data = parse_trim_summary_paired(tf)
             else:
                 trim_data = parse_trim_summary_single(tf)

--- a/sunbeamlib/reports.py
+++ b/sunbeamlib/reports.py
@@ -30,6 +30,57 @@ def blast_contig_summary(xml_files):
 
 def blast_hits(blast_xml_files):
     return Counter(c['query'] for c in blast_summary(blast_xml_files))
+
+def parse_trim_summary_paired(f):
+    for line in f.readlines():
+        if line.startswith('Input Read'):
+            vals = re.findall('\D+\: (\d+)', line)
+            keys = ('input', 'both_kept','fwd_only','rev_only','dropped')
+            return(OrderedDict(zip(keys, vals)))
+
+def parse_trim_summary_single(f):
+    for line in f:
+        if line.startswith('Input Read'):
+            vals = re.findall('\D+\: (\d+)', line)
+            keys = ('input', 'kept', 'dropped')
+            return(OrderedDict(zip(keys, vals)))
+
+def parse_decontam_log(f):
+    keys = f.readline().rstrip().split('\t')
+    vals = f.readline().rstrip().split('\t')
+    return(OrderedDict(zip(keys,vals)))
+
+def summarize_qual_decontam(tfile, dfile):
+    """Return a dataframe for summary information for trimmomatic and decontam rule"""
+    tname = os.path.basename(tfile).split('.out')[0]
+    dname = os.path.basename(dfile).split('.txt')[0]
+    with open(tfile) as tf:
+        with open(dfile) as jf:
+            if Cfg['all']['paired_end']:
+                trim_data = parse_trim_summary_paired(tf)
+            else:
+                trim_data = parse_trim_summary_single(tf)
+                
+            decontam_data = parse_decontam_log(jf)
+    sys.stderr.write("trim data: {}\n".format(trim_data))
+    sys.stderr.write("decontam data: {}\n".format(decontam_data))
+    return(pandas.DataFrame(OrderedDict(trim_data, **(decontam_data)), index=[tname]))
+
+def parse_fastqc_quality(filename):
+    with open(filename) as f:
+        report = f.read()
+    tableString = re.search(
+        '\>\>Per base sequence quality.*?\n(.*?)\n\>\>END_MODULE',
+        report, re.DOTALL).group(1)
+
+    f_s = StringIO(tableString)
+    df = pandas.read_csv(
+        f_s, sep='\t', usecols=['#Base', 'Mean'], index_col='#Base')
+    sample_name = os.path.basename(filename.split('_fastqc')[0])
+    df.columns=[sample_name]
+    f_s.close()
+    return(df)
+
     
 
 


### PR DESCRIPTION
Bugfixes related to sample name guessing. In particular:

- can now work with sample names that have consistent ends (like `_001.fastq.gz`) but inconsistent numbers of underscores preceding the end (like `extractionblank_S01_L001_R1_001.fastq.gz` vs `S_123_S01_L001_R1_001.fastq.gz`)
- now understands and ignores index files (I1 and I2) in the data directory
- added new tests for sample parsing edge cases like these