### PR TITLE
Trimmomatic dependency lock

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - snakemake=4.8.1
   - ruamel.yaml
   - biopython
-  - trimmomatic
+  - trimmomatic=0.36
   - fastqc
   - blast
   - kraken=1.0


### PR DESCRIPTION
Potentially fixes #156

* [ ] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
