### PR TITLE
change backtick to single quote

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -29,7 +29,7 @@ runs some tests to make sure everything was installed correctly.
    If you've never installed Conda before, you'll need to add it to your shell's
    path. If you're running Bash (the most common terminal shell), the following
    command will add it to your path: ``echo 'export
-   PATH=$PATH:$HOME/miniconda3/bin` > ~/.bashrc``
+   PATH=$PATH:$HOME/miniconda3/bin' > ~/.bashrc``
 
 If you see "Tests failed", check out our :ref:`troubleshooting` section or file an issue
 on our `GitHub <https://github.com/sunbeam-labs/sunbeam/issues>`_ page.


### PR DESCRIPTION
so that users can copy-paste without syntax error

* [ ] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
