### PR TITLE
Fix 154: reorganize CSV generation in mapping rules

### DIFF
--- a/rules/mapping/mapping.rules
+++ b/rules/mapping/mapping.rules
@@ -32,7 +32,6 @@ rule align_to_genome:
         {input.reads} -o {output}
         """
 
-
 rule samtools_convert:
     input:
         str(MAPPING_FP/'intermediates'/'{genome}'/'{sample}.sam')
@@ -46,15 +45,25 @@ rule samtools_convert:
         samtools sort -@ {threads} > {output}
         """
 
-rule samtools_get_coverage:
-    input:
-        expand(
-            str(MAPPING_FP/'{{genome}}'/'{sample}.bam'), sample=Samples.keys())
+def _sorted_csvs(w):
+    pattern = str(MAPPING_FP/'intermediates'/w.genome/'{sample}.csv')
+    paths = sorted(expand(pattern, sample=Samples.keys()))
+    return(paths)
+
+rule samtools_summarize_coverage:
+    input: _sorted_csvs
     output:
         str(MAPPING_FP/'{genome}'/'coverage.csv')
+    shell: "(head -n 1 {input[0]}; tail -q -n +2 {input}) > {output}"
+
+rule samtools_get_coverage:
+    input:
+        str(MAPPING_FP/'{genome}'/'{sample}.bam')
+    output:
+        str(MAPPING_FP/'intermediates'/'{genome}'/'{sample}.csv')
     run:
         samtools.get_coverage_stats(
-            wildcards.genome, input, Samples.keys(), output[0])
+            wildcards.genome, input[0], wildcards.sample, output[0])
 
 rule samtools_index:
     input: str(MAPPING_FP/'{genome}'/'{sample}.bam')
@@ -72,5 +81,3 @@ rule samtools_mpileup:
         samtools mpileup -gf {input.genome} {input.bam} | \
         bcftools call -Ob -v -c - > {output}
         """
-
-    

--- a/sunbeamlib/samtools.py
+++ b/sunbeamlib/samtools.py
@@ -4,41 +4,41 @@ import subprocess
 import numpy
 import csv
 
-def get_coverage_stats(genome_name, bamfiles, sample_names, output_fp):
-    """Produce a CSV table of alignment stats for a single genome.
+def get_coverage_stats(genome_name, bamfile, sample, output_fp):
+    """Produce a CSV table of alignment stats for a single genome and sample.
     
     genome_name: identifier for genome
-    bamfiles: list of file paths to BAM files
-    sample_names: list of idenifiers for the sample for each BAM file
+    bamfile: path to BAM file
+    sample: idenifier for the sample
     output_fp: path to CSV output file
 
     There's lot of redundant information (genome name on every row, segment
     name and stats across all relevant rows) but it makes the results a bit
     easier to work with.
     """
+    # Get coverage depth at each position, even if zero across whole segment
     output_rows = []
-    for bamfile, sample in sorted(zip(bamfiles, sample_names)):
-        # Get coverage depth at each position, even if zero across whole segment
-        args = ["samtools", "depth", "-aa", bamfile]
-        p = subprocess.Popen(args, stdout=subprocess.PIPE, universal_newlines=True)
-        # Organize into a list of depths for each segment, streaming in text
-        reader = csv.reader(p.stdout, delimiter='\t')
-        data = {}
-        for row in reader:
-            if not data.get(row[0]):
-                data[row[0]] = []
-            data[row[0]].append(int(row[2]))
-        # Summarize stats for all segments present and append to output
-        for segment in data.keys():
-            minval     = numpy.min(data[segment])
-            maxval     = numpy.max(data[segment])
-            mean       = numpy.mean(data[segment])
-            median     = numpy.median(data[segment])
-            stddev     = numpy.std(data[segment])
-            gen_cov    = len(list(filter(lambda x: x!=0, data[segment])))
-            gen_length = len(data[segment])
-            row = [genome_name, segment, sample, minval, maxval, mean, median, stddev, gen_cov, gen_length]
-            output_rows.append(row)
+    args = ["samtools", "depth", "-aa", bamfile]
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, universal_newlines=True)
+    # Organize into a list of depths for each segment, streaming in text
+    reader = csv.reader(p.stdout, delimiter='\t')
+    data = {}
+    for row in reader:
+        if not data.get(row[0]):
+            data[row[0]] = []
+        data[row[0]].append(int(row[2]))
+    # Summarize stats for all segments present and append to output
+    for segment in data.keys():
+        minval     = numpy.min(data[segment])
+        maxval     = numpy.max(data[segment])
+        mean       = numpy.mean(data[segment])
+        median     = numpy.median(data[segment])
+        stddev     = numpy.std(data[segment])
+        gen_cov    = len(list(filter(lambda x: x!=0, data[segment])))
+        gen_length = len(data[segment])
+        row = [genome_name, segment, sample, minval, maxval, mean, median, stddev, gen_cov, gen_length]
+        output_rows.append(row)
+
     # write out stats per segment per sample
     fields = ['Genome', 'Segment', 'Sample', 'Min', 'Max', 'Mean', 'Median', 'Std Dev', 'Segment Coverage', 'Segment Length']
     with open(output_fp, 'w') as f:

--- a/sunbeamlib/samtools.py
+++ b/sunbeamlib/samtools.py
@@ -19,11 +19,10 @@ def get_coverage_stats(genome_name, bamfiles, sample_names, output_fp):
     output_rows = []
     for bamfile, sample in sorted(zip(bamfiles, sample_names)):
         # Get coverage depth at each position, even if zero across whole segment
-        p = subprocess.Popen(["samtools", "depth", "-aa", bamfile], stdout=subprocess.PIPE)
-        stdout, stderr = p.communicate()
-        # Organize into a list of depths for each segment
-        lines = str(stdout, 'ascii').splitlines()
-        reader = csv.reader(lines, delimiter='\t')
+        args = ["samtools", "depth", "-aa", bamfile]
+        p = subprocess.Popen(args, stdout=subprocess.PIPE, universal_newlines=True)
+        # Organize into a list of depths for each segment, streaming in text
+        reader = csv.reader(p.stdout, delimiter='\t')
         data = {}
         for row in reader:
             if not data.get(row[0]):

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -133,35 +133,53 @@ function test_blank_fp_behavior {
     [ ! -f $TEMPDIR/sunbeam_output/mapping/indexes_phix174/coverage.csv ]
 }
 
-# Test that mapping reports an aligning read pair for a contrived example.
+# Test that mapping reports aligning read pairs for a contrived example.
 # This could maybe be rolled into test_all (as the annotation check already is)
 # if the data setup were reorganized.
 function test_mapping {
-    # Create a single read pair using a line from the human genome fasta.
-    r1=$TEMPDIR/data_files/PCMP_stub_human_R1.fastq.gz
-    r2=$TEMPDIR/data_files/PCMP_stub_human_R2.fastq.gz
+    # Create two read pairs using lines from the human genome fasta.
+    r1_1=$TEMPDIR/data_files/PCMP_stub_human_R1.fastq.gz
+    r2_1=$TEMPDIR/data_files/PCMP_stub_human_R2.fastq.gz
+    r1_2=$TEMPDIR/data_files/PCMP_stub2_human_R1.fastq.gz
+    r2_2=$TEMPDIR/data_files/PCMP_stub2_human_R2.fastq.gz
     human=$TEMPDIR/indexes/human.fasta
     (
         echo "@read0"
         sed -n 2p $human
         echo "+"
         sed -n 's:.:G:g;2p' $human
-    ) | gzip > $r1
+    ) | gzip > $r1_1
     (
         echo "@read0"
         sed -n 2p $human | rev | tr '[ACTG]' '[TGAC]'
         echo "+"
         sed -n 's:.:G:g;2p' $human
-    ) | gzip > $r2
-    # Run sunbeam mapping rules with this one sample defined.
-    echo "stub_human,$r1,$r2" > $TEMPDIR/samples_test_mapping.csv
+    ) | gzip > $r2_1
+    (
+        echo "@read0"
+        sed -n 15p $human | cut -c 1-40
+        echo "+"
+        sed -n 's:.:G:g;2p' $human | cut -c 1-40
+    ) | gzip > $r1_2
+    (
+        echo "@read0"
+        sed -n 15p $human | cut -c 1-40 | rev | tr '[ACTG]' '[TGAC]'
+        echo "+"
+        sed -n 's:.:G:g;2p' $human | cut -c 1-40
+    ) | gzip > $r2_2
+    # Run sunbeam mapping rules with these two samples defined.
+    (
+	    echo "stub_human,$r1_1,$r2_1"
+	    echo "stub2_human,$r1_2,$r2_2"
+    ) > $TEMPDIR/samples_test_mapping.csv
     sunbeam config modify --str 'all: {samplelist_fp: "samples_test_mapping.csv"}' \
         $TEMPDIR/tmp_config.yml > $TEMPDIR/test_mapping_config.yml
-    # There should be a single line in the human coverage summary and none at
-    # all in the phix174 summary.
+    # There should be two lines in the human coverage summary and none at all
+    # in the phix174 summary.  The human.csv lines should be sorted in standard
+    # alphanumeric order; stub2_human will come before stub_human.
     sunbeam run --configfile $TEMPDIR/test_mapping_config.yml all_mapping
     md5sum --check --status <(
-    echo "500f06298d4113458360e07fa48e7b63  $TEMPDIR/sunbeam_output/mapping/human/coverage.csv"
+    echo "c624406eb2582cac5e0cfb160c79a900  $TEMPDIR/sunbeam_output/mapping/human/coverage.csv"
     echo "1aee435ade0310a6b3c63d44cbdc2029  $TEMPDIR/sunbeam_output/mapping/phix174/coverage.csv"
     )
 }


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [x] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

This updates samtools.get_coverage_stats to stream samtools' output text instead of holding it in memory, and reorganizes the Snakemake mapping rules to run separately for each sample until a final concatenation step.
