### PR TITLE
Contigs coverage

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -58,6 +58,7 @@ Blastdbs = process_databases(Cfg['blastdbs'])
 Samples = load_sample_list(Cfg['all']['samplelist_fp'], Cfg['all']['paired_end'], Cfg['all']['download_reads'], Cfg["all"]['root']/Cfg['all']['output_fp'])
 Pairs = ['1', '2'] if Cfg['all']['paired_end'] else ['1']
 
+
 # Collect host (contaminant) genomes
 sys.stderr.write("Collecting host/contaminant genomes... ")
 if Cfg['qc']['host_fp'] == Cfg['all']['root']:
@@ -94,7 +95,6 @@ ANNOTATION_FP = output_subdir(Cfg, 'annotation')
 CLASSIFY_FP = output_subdir(Cfg, 'classify')
 MAPPING_FP = output_subdir(Cfg, 'mapping')
 
-print(DOWNLOAD_FP)
 
 # ---- Download rules
 if Cfg['all']['download_reads']:
@@ -112,6 +112,7 @@ include: "rules/qc/decontaminate.rules"
 
 # ---- Assembly rules
 include: "rules/assembly/assembly.rules"
+include: "rules/assembly/coverage.rules"
 
 
 # ---- Contig annotation rules

--- a/environment.yml
+++ b/environment.yml
@@ -25,3 +25,4 @@ dependencies:
   - komplexity=0.3.6
   - rust-bio-tools
   - grabseqs=0.2.1
+  - minimap2

--- a/rules/assembly/assembly.rules
+++ b/rules/assembly/assembly.rules
@@ -21,7 +21,20 @@ rule megahit_paired:
         out_fp = str(ASSEMBLY_FP/'megahit'/'{sample}_asm')
     shell:
         """
-        megahit -1 {input.r1} -2 {input.r2} -o {params.out_fp} --continue || \
+        ## turn off bash strict mode
+        set +o pipefail
+
+        ## sometimes the error is due to lack of memory
+        exitcode=0
+        megahit -1 {input.r1} -2 {input.r2} -o {params.out_fp} --continue || exitcode=$?
+        
+        if [ $exitcode -eq 255 ]
+        then
+            echo "Empty contigs"
+        elif [ $exitcode -gt 1 ]
+        then
+            echo "Check your memory"
+        fi
         if [ ! -a {output} ]; then touch {output}; fi
         """
           
@@ -34,7 +47,20 @@ rule megahit_unpaired:
         out_fp = str(ASSEMBLY_FP/'megahit'/'{sample}_asm')
     shell:
         """
-        megahit -r {input} -o {params.out_fp} --continue || \
+        ## turn off bash strict mode
+        set +o pipefail
+
+        ## sometimes the error is due to lack of memory
+        exitcode=0
+        megahit -r {input} -o {params.out_fp} --continue || exitcode=$?
+
+        if [ $exitcode -eq 255 ]
+        then
+            echo "Empty contigs"
+        elif [ $exitcode -gt 1 ]
+        then
+            echo "Check your memory"
+        fi
         if [ ! -a {output} ]; then touch {output}; fi
         """
 

--- a/rules/assembly/coverage.rules
+++ b/rules/assembly/coverage.rules
@@ -1,0 +1,107 @@
+# -*- mode: Snakemake -*-
+#
+# Map reads to contigs and calculate per base coverage
+#
+# Requires Minimap2 and samtools.
+
+
+import csv
+import numpy
+
+
+rule all_coverage:
+    input:
+        str(ASSEMBLY_FP/'contigs_coverage.txt')
+
+rule _contigs_mapping:
+    input:
+        expand(str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth'),
+               sample=Samples.keys())        
+
+rule _all_coverage:
+    input:
+        expand(str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv'),
+               sample=Samples.keys())
+
+rule contigs_mapping:
+    input:
+        contig = str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa'),
+        reads = expand(str(QC_FP/'decontam'/'{{sample}}_{rp}.fastq.gz'),rp = Pairs)
+    output:
+        bam = str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam'),
+        bai = str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam.bai')
+    params:
+        temp = temp(str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.tmp'))
+    threads: 
+        Cfg['mapping']['threads']
+    shell:
+        """
+        minimap2 -ax sr -t {threads} {input.contig} {input.reads} | \
+            samtools sort -@ {threads} -o {output.bam} -T {params.temp} - 
+        samtools index {output.bam} {output.bai}
+        """
+
+rule mapping_depth:
+    input:
+        bam = str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam'),
+        bai = str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam.bai')
+    output:
+        depth = str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth')
+    shell:
+        """
+        samtools depth -aa {input.bam} > {output.depth}
+        """
+
+def _get_coverage(input_fp, sample, output_fp):
+    """
+    Summarize stats for coverage data for each sample 
+    """
+
+    with open(input_fp) as f:
+        reader = csv.reader(f, delimiter='\t')    
+        data = {}
+        for row in reader:
+            if not data.get(row[0]):
+                data[row[0]] = []
+            data[row[0]].append(int(row[2]))
+    
+    # summarize stats for all segments present and append to output
+    output_rows = []
+    for segment in data.keys():
+        sumval     = numpy.sum(data[segment])
+        minval     = numpy.min(data[segment])
+        maxval     = numpy.max(data[segment])
+        mean       = numpy.mean(data[segment])
+        median     = numpy.median(data[segment])
+        stddev     = numpy.std(data[segment])
+        gen_cov    = len(list(filter(lambda x: x!=0, data[segment])))
+        gen_length = len(data[segment])
+        row = [sample, segment, sumval, minval, maxval, mean, median, stddev, gen_cov, gen_length]
+        output_rows.append(row)
+
+    # write out stats per segment per sample
+    fields = ['sample','contig', 'sum', 'min', 'max', 'mean', 'median', 'stddev', 'coverage', 'length']
+    with open(output_fp, 'w') as f:
+        writer = csv.writer(f)
+        writer.writerow(fields)
+        writer.writerows(output_rows)
+
+
+rule get_coverage:
+    input:
+        str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth')
+    output:
+        str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv')
+    run:
+        _get_coverage(input[0], wildcards.sample, output[0])
+
+
+rule summarize_coverage:
+    input:
+        expand(str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv'), 
+               sample = Samples.keys())
+    output:
+        str(ASSEMBLY_FP/'contigs_coverage.txt')
+    shell:
+        "(head -n 1 {input[0]}; tail -q -n +2 {input}) > {output}"
+

--- a/rules/targets/targets.rules
+++ b/rules/targets/targets.rules
@@ -58,7 +58,8 @@ TARGET_ANNOTATE = expand(
 # ---- Reports
 TARGET_REPORT = [
     str(QC_FP/'reports'/'preprocess_summary.tsv'),
-    str(QC_FP/'reports'/'fastqc_quality.tsv')
+    str(QC_FP/'reports'/'fastqc_quality.tsv'),
+    str(ASSEMBLY_FP/'contigs_coverage.txt')
 ]
 
 

--- a/tests/targets.txt
+++ b/tests/targets.txt
@@ -9,6 +9,7 @@ annotation/summary/random.tsv
 assembly/contigs/dummybfragilis-contigs.fa
 assembly/contigs/dummyecoli-contigs.fa
 assembly/contigs/random-contigs.fa
+assembly/contigs_coverage.txt
 
 classify/kraken/all_samples.biom
 classify/kraken/all_samples.tsv


### PR DESCRIPTION
* [V] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [V] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [V] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

After de novo the contigs, we added the mapping reads back to all the contigs using minimap2 to get the per-base coverage statistics. This is helpful for any extensions based need to quantify the genes' abundance (e.g. RPKM).
