### PR TITLE
Dummy output

### DIFF
--- a/rules/assembly/assembly.rules
+++ b/rules/assembly/assembly.rules
@@ -4,10 +4,16 @@
 #
 # Requires Megahit.
 
+rule Assembled:
+    input:
+        str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa') 
+    output:
+        str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa')
+
 rule all_assembly:
     """Build contigs for all samples."""
     input:
-        TARGET_ASSEMBLY
+        expand(rules.Assembled.output, sample = Samples.keys())
 
 ruleorder: megahit_paired > megahit_unpaired
           

--- a/rules/classify/kraken.rules
+++ b/rules/classify/kraken.rules
@@ -2,6 +2,12 @@
 #
 # Rules for running Kraken
 
+rule Classified:
+    input:
+        str(CLASSIFY_FP/'kraken'/'{sample}-taxa.tsv')
+    output:
+        str(CLASSIFY_FP/'kraken'/'{sample}-taxa.tsv')
+
 rule all_classify:
     input:
         TARGET_CLASSIFY

--- a/rules/qc/decontaminate.rules
+++ b/rules/qc/decontaminate.rules
@@ -10,9 +10,7 @@ rule Decontaminated:
 
 rule all_decontam:
     input:
-        expand(
-            str(QC_FP/'decontam'/'{sample}_{rp}.fastq.gz'),
-            sample=Samples.keys(), rp=Pairs)
+        expand(rules.Decontaminated.output, sample=Samples.keys(), rp=Pairs)
 
 ruleorder: build_host_index > build_genome_index
         

--- a/rules/qc/decontaminate.rules
+++ b/rules/qc/decontaminate.rules
@@ -2,6 +2,12 @@ import subprocess
 from sunbeamlib.decontam import get_mapped_reads
 from collections import OrderedDict
 
+rule Decontaminated:
+    input:
+       str(QC_FP/'decontam'/'{sample}_{rp}.fastq.gz')
+    output:
+       str(QC_FP/'decontam'/'{sample}_{rp}.fastq.gz')
+
 rule all_decontam:
     input:
         expand(

--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -2,6 +2,12 @@
 #
 # Illumina quality control rules
 
+rule QualityControled:
+    input:
+        str(QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz')
+    output:
+        str(QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz')
+
 rule all_qc:
     """Runs trimmomatic and fastqc on all input files."""
     input:


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully

I added dummy output for `qc`, `decontaminate`, `assembly` and `classify` rules, which can be easily used in the extensions. For example, for any extensions that needs the fastq files from the decontam, we can simply use `rules.Decontaminated.output` as the input. For any extensions that built on the `contigs`,  we can simply use `rules.Assembled.output`.