### PR TITLE
Fix sunbeam get tests and paired/unpaired feature

### DIFF
--- a/sunbeamlib/scripts/get.py
+++ b/sunbeamlib/scripts/get.py
@@ -95,7 +95,12 @@ def main(argv=sys.argv):
             cfg = config.update(cfg, defaults)
         paired = layout == "paired"
         sample_file = samplelists[layout].name
-        cfg = config.update(cfg, {"all":{"paired_end":paired, "download_reads":True}})
+        cfg_new = {"all": {
+            "paired_end": paired,
+            "samplelist_fp": samplelists[layout].name,
+            "download_reads": True
+            }}
+        cfg = config.update(cfg, cfg_new)
         with config_file.open('w') as out:
             config.dump(cfg, out)
         sys.stderr.write("New config file written to {}\n".format(config_file))

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -190,14 +190,24 @@ function test_mapping {
 function test_sunbeam_get {
     mkdir -p $TEMPDIR/test_sunbeam_get
     sunbeam get --force --output sunbeam_config_SRA.yml $TEMPDIR/test_sunbeam_get --data_acc SRP021545
-    a=`wc -l < $TEMPDIR/test_sunbeam_get/samples.csv`
-    test "$a" -eq 89
+    test `wc -l < $TEMPDIR/test_sunbeam_get/samples.csv` -eq 89
 }
 
 # Test for sunbeam get -- study with paired and unpaired samples
 # Make sure Sunbeam exits with nonzero exit code if a study contains paired and unpaired reads
+# Both sets should be written separately to a config/samples.csv pair of files
 
-#function test_get_paired_unpaired {
-#    mkdir -p $TEMPDIR/test_get_paired_unpaired
-#    sunbeam get --force --output sunbeam_config_SRA.yml $TEMPDIR/test_get_paired_unpaired --data_acc ERP020555 && exit 0 || exit 0
-#}
+function test_get_paired_unpaired {
+    dp=$TEMPDIR/test_get_paired_unpaired
+    mkdir -p $dp
+    # "!" because we *expect* this to exit nonzero.
+    ! sunbeam get --force --output sunbeam_config_SRA.yml $dp --data_acc ERP020555
+    # Check contents of the two config files
+    grep '^  samplelist_fp: samples_unpaired.csv$' $dp/unpaired_sunbeam_config_SRA.yml
+    grep '^  paired_end: false$'                   $dp/unpaired_sunbeam_config_SRA.yml
+    grep '^  samplelist_fp: samples_paired.csv$'   $dp/paired_sunbeam_config_SRA.yml
+    grep '^  paired_end: true$'                    $dp/paired_sunbeam_config_SRA.yml
+    # Check contents of the two samples csv files
+    test `wc -l < $dp/samples_unpaired.csv` -eq  1
+    test `wc -l < $dp/samples_paired.csv`   -eq  13
+}

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -189,11 +189,9 @@ function test_mapping {
 
 function test_sunbeam_get {
     mkdir -p $TEMPDIR/test_sunbeam_get
-    sunbeam get --force --output sunbeam_config_SRA.yml $TEMPDIR/test_sunbeam_get --data_acc SRP159164
-    a=`wc -l $TEMPDIR/test_sunbeam_get/samples.csv`
-    if [ "$a" -ne "34" ]; then
-        exit 1
-    fi
+    sunbeam get --force --output sunbeam_config_SRA.yml $TEMPDIR/test_sunbeam_get --data_acc SRP021545
+    a=`wc -l < $TEMPDIR/test_sunbeam_get/samples.csv`
+    test "$a" -eq 89
 }
 
 # Test for sunbeam get -- study with paired and unpaired samples


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [X] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

For `test_sunbeam_get` I switched from SRP159164 to SRP021545 to ensure we have an unpaired-only test case.  (Fixes #177.)

For `test_get_paired_unpaired` I finished our test of the  mixed paired/unpaired case and included checks on the config files as well as the sample lists.    (Fixes #176.)