### PR TITLE
rule blast xml to txt and another rule to clean blast

### DIFF
--- a/rules/annotation/blast.rules
+++ b/rules/annotation/blast.rules
@@ -49,7 +49,7 @@ rule run_blastp:
         -outfmt 5 \
         -num_threads {threads} \
         -evalue 1e-10 \
-        -max_target_seqs 1 \
+        -max_target_seqs 2475 \
         -out {output} \
         """
 
@@ -70,7 +70,7 @@ rule run_blastx:
         -outfmt 5 \
         -num_threads {threads} \
         -evalue 1e-10 \
-        -max_target_seqs 1 \
+        -max_target_seqs 2475 \
         -out {output} \
         """
         

--- a/rules/annotation/blast.rules
+++ b/rules/annotation/blast.rules
@@ -100,3 +100,19 @@ rule _test_blastpx_report:
     input:
         expand(str(ANNOTATION_FP/'{blastpx}'/'card'/'prodigal'/'report.tsv'),
         blastpx=['blastx','blastp'])
+
+rule clean_xml:
+    input:
+        expand(str(ANNOTATION_FP/'summary'/'{sample}.tsv'), sample=Samples.keys())
+    params:
+        blastn_fp = str(ANNOTATION_FP/'blastn'),
+        blastp_fp = str(ANNOTATION_FP/'blastp'),
+        blastx_fp = str(ANNOTATION_FP/'blastx')
+    output:
+        touch(".xml_cleaned")
+    shell:
+        """
+        if [ -d {params.blastn_fp} ]; then rm -r {params.blastn_fp}; fi && \
+        if [ -d {params.blastp_fp} ]; then rm -r {params.blastp_fp}; fi && \
+        if [ -d {params.blastx_fp} ]; then rm -r {params.blastx_fp}; fi
+        """

--- a/rules/annotation/blast.rules
+++ b/rules/annotation/blast.rules
@@ -28,7 +28,7 @@ rule run_blastn:
         -outfmt 5 \
         -num_threads {threads} \
         -evalue 1e-10 \
-        -max_target_seqs 1 \
+        -max_target_seqs 5000 \
         -out {output} \
         """
 


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully

1. The issue with `--max_target_seqs 1` is that: max target sequences are applied in an early ungapped phase of the algorithm, as well as later, aka the **internal alignment limit** mentioned in this [blog](https://blastedbio.blogspot.com/2018/11/blast-max-alignment-limits-part-four.html). In some cases a final HSP will improve enough in the later gapped phase to rise to the top hits. Therefore a small `max_target_seqs` may end up with a incomplete search and report the top hits related to the database order. 

On the other hand, `blast[px]` and `blastn` are using different equation for this internal search limit, and considering the number of refseq genomes of well studied bacteria strains, I think 5000 should be a good candidate.

2. Due to the large space XML files take, we added a `clean_xml` rule, similar to the `clean_qc` rule.
