### PR TITLE
Run megahit multithreaded

### DIFF
--- a/rules/assembly/assembly.rules
+++ b/rules/assembly/assembly.rules
@@ -19,6 +19,8 @@ rule megahit_paired:
         str(ASSEMBLY_FP/'megahit'/'{sample}_asm'/'final.contigs.fa')
     params:
         out_fp = str(ASSEMBLY_FP/'megahit'/'{sample}_asm')
+    threads:
+        Cfg['assembly']['threads']
     shell:
         """
         ## turn off bash strict mode
@@ -26,7 +28,7 @@ rule megahit_paired:
 
         ## sometimes the error is due to lack of memory
         exitcode=0
-        megahit -1 {input.r1} -2 {input.r2} -o {params.out_fp} --continue || exitcode=$?
+        megahit -t {threads} -1 {input.r1} -2 {input.r2} -o {params.out_fp} --continue || exitcode=$?
         
         if [ $exitcode -eq 255 ]
         then
@@ -45,6 +47,8 @@ rule megahit_unpaired:
         str(ASSEMBLY_FP/'megahit'/'{sample}_asm'/'final.contigs.fa')
     params:
         out_fp = str(ASSEMBLY_FP/'megahit'/'{sample}_asm')
+    threads:
+        Cfg['assembly']['threads']
     shell:
         """
         ## turn off bash strict mode
@@ -52,7 +56,7 @@ rule megahit_unpaired:
 
         ## sometimes the error is due to lack of memory
         exitcode=0
-        megahit -r {input} -o {params.out_fp} --continue || exitcode=$?
+        megahit -t {threads} -r {input} -o {params.out_fp} --continue || exitcode=$?
 
         if [ $exitcode -eq 255 ]
         then


### PR DESCRIPTION
Use the same `Cfg[section]['threads']` idiom used elsewhere to control megahit's multithreading via the config file.  We already have an entry for it in the default config file, but it wasn't in use.  This fixes #188.

This doesn't add any more detailed output checking than we already have, but that could be a separate improvement on the testing side.

* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
