### PR TITLE
Enforce sample wildcard constraints

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -20,11 +20,6 @@ from sunbeamlib import load_sample_list, read_seq_ids
 from sunbeamlib.config import *
 from sunbeamlib.reports import *
 
-# Disallow slashes in our sample names during Snakemake's wildcard evaluation.
-# Slashes should always be interpreted as directory separators.
-wildcard_constraints:
-  sample="[^/]+"
-
 # Load config file
 if not config:
     raise SystemExit(

--- a/Snakefile
+++ b/Snakefile
@@ -20,6 +20,11 @@ from sunbeamlib import load_sample_list, read_seq_ids
 from sunbeamlib.config import *
 from sunbeamlib.reports import *
 
+# Disallow slashes in our sample names during Snakemake's wildcard evaluation.
+# Slashes should always be interpreted as directory separators.
+wildcard_constraints:
+  sample="[^/]+"
+
 # Load config file
 if not config:
     raise SystemExit(

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -185,6 +185,7 @@ function build_test_data {
     cp -r raw $TEMPDIR
     cp -r truncated_taxonomy $TEMPDIR
     cp -r sbx_test $STARTING_DIR/$SBX_FP/sbx_test
+    cp -r sbx_test_subdir $STARTING_DIR/$SBX_FP/sbx_test_subdir
     cp seqid2taxid.map $TEMPDIR
 
     mkdir -p $TEMPDIR/hosts

--- a/tests/sbx_test_subdir/sbx_test_subdir.rules
+++ b/tests/sbx_test_subdir/sbx_test_subdir.rules
@@ -1,0 +1,12 @@
+# Check that Snakemake can resolve nested subdirectories as expected when
+# building the DAG.  (Note that since this is all rule-dependency-related we
+# don't actually need any actions defined here.) See test_subdir_patterns.
+rule sbx_test_subdir:
+    input:
+         expand(str(QC_FP/'decontam'/'full'/'{sample}_{rp}.fastq.gz'), sample=Samples.keys(), rp=Pairs)
+
+rule sample_reads:
+    input:
+        str(QC_FP/'decontam'/'{sample}_{rp}.fastq.gz')
+    output:
+        str(QC_FP/'decontam'/'full'/'{sample}_{rp}.fastq.gz')

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -220,3 +220,14 @@ function test_get_paired_unpaired {
     test `wc -l < $dp/samples_unpaired.csv` -eq  1
     test `wc -l < $dp/samples_paired.csv`   -eq  13
 }
+
+# Fix for #185:
+# While the core Sunbeam rules keep a simple directory structure, using more
+# complicated nested subdirectories can complicate the wildcard/graph
+# resolution in Snakemake and result in unexpected wildcard patterns being
+# evaluated.  Enforcing a pattern on our sample names (no slashes allowed)
+# avoids this.
+function test_subdir_patterns {
+    # All we need to check is that the graph resolution works.
+    sunbeam run --configfile $TEMPDIR/tmp_config.yml sbx_test_subdir -n
+}


### PR DESCRIPTION
This creates a top-level `wildcard_constraints` entry in the Snakefile to disallow slashes in sample names when Snakemake builds its dependency graph and tests out different possible wildcard values.  This fixes #185.

This is a small change, but it's a modification to Snakemake's settings for the whole tree, so I want to make sure all looks good and I'm not missing anything.  I added an extension-based test to the test suite (modeled after sbx_test) that demonstrates the problem.  I also skimmed the rules files for existing extensions to make sure nothing is somehow relying on the existing behavior, and nothing jumped out at me, but I'll be glad to have any others' input too.

* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [X] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
