### PR TITLE
New megahit failure handling

### DIFF
--- a/rules/assembly/assembly.rules
+++ b/rules/assembly/assembly.rules
@@ -33,11 +33,11 @@ rule megahit_paired:
         if [ $exitcode -eq 255 ]
         then
             echo "Empty contigs"
+            touch {output}
         elif [ $exitcode -gt 1 ]
         then
             echo "Check your memory"
         fi
-        if [ ! -a {output} ]; then touch {output}; fi
         """
           
 rule megahit_unpaired:
@@ -61,11 +61,11 @@ rule megahit_unpaired:
         if [ $exitcode -eq 255 ]
         then
             echo "Empty contigs"
+            touch {output}
         elif [ $exitcode -gt 1 ]
         then
             echo "Check your memory"
         fi
-        if [ ! -a {output} ]; then touch {output}; fi
         """
 
 rule final_filter:

--- a/rules/assembly/assembly.rules
+++ b/rules/assembly/assembly.rules
@@ -10,7 +10,7 @@ rule all_assembly:
         TARGET_ASSEMBLY
 
 ruleorder: megahit_paired > megahit_unpaired
-          
+
 rule megahit_paired:
     input:
         r1 = str(QC_FP/'decontam'/'{sample}_1.fastq.gz'),
@@ -29,7 +29,7 @@ rule megahit_paired:
         ## sometimes the error is due to lack of memory
         exitcode=0
         megahit -t {threads} -1 {input.r1} -2 {input.r2} -o {params.out_fp} --continue || exitcode=$?
-        
+
         if [ $exitcode -eq 255 ]
         then
             echo "Empty contigs"
@@ -39,7 +39,7 @@ rule megahit_paired:
             echo "Check your memory"
         fi
         """
-          
+
 rule megahit_unpaired:
     input:
         str(QC_FP/'decontam'/'{sample}_1.fastq.gz')

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -231,3 +231,34 @@ function test_subdir_patterns {
     # All we need to check is that the graph resolution works.
     sunbeam run --configfile $TEMPDIR/tmp_config.yml sbx_test_subdir -n
 }
+
+# Fix for #167:
+# Check that if megahit gives a nonzero exit code it is handled appropriately.
+# The two main cases are 255 (empty contigs) and anything else nonzero
+# (presumed to be memory-related in the assembly rules).
+# Checking for successful behavior is already handled in test_all.
+function test_assembly_failures {
+    # Up to just before the assembly rules, things should work fine.
+    sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p all_decontam
+    # Remove previous assembly files, if they exist.
+    rm -rf $TEMPDIR/sunbeam_output/assembly
+    # If megahit gives an exit code != 0 and != 255 it is an error.
+    mkdir -p "$TEMPDIR/megahit_137"
+    echo -e '#!/usr/bin/env bash\nexit 137' > $TEMPDIR/megahit_137/megahit
+    chmod +x $TEMPDIR/megahit_137/megahit
+    (
+    export PATH="$TEMPDIR/megahit_137:$PATH"
+    # (This command should *not* exit successfully.)
+    ! txt=$(sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p all_assembly)
+    echo "$txt" | grep "Check your memory"
+    )
+    # If megahit exits with 255, it implies no contigs were built.
+    mkdir -p "$TEMPDIR/megahit_255"
+    echo -e '#!/usr/bin/env bash\nexit 255' > $TEMPDIR/megahit_255/megahit
+    chmod +x $TEMPDIR/megahit_255/megahit
+    (
+    export PATH="$TEMPDIR/megahit_255:$PATH"
+    txt=$(sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p all_assembly)
+    echo "$txt" | grep "Empty contigs"
+    )
+}


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [X] If this fixes a bug, I have added an appropriate test to tests/test.sh

This fixes #167 (in my view) by making megahit failures more obvious for every exit code except the 255 "Empty contigs" case.  Here if the exit code is anything except 255 (which will include 137 for SIGKILL/out-of-memory cases) no output file appears and the rule fails.  The output messages @zhaoc1 previously set up for these cases still appear as before.  Chunyu how does this sound to you?

One thing: For the new test case I used mock megahit executables (just tiny bash scripts) to produce the different exit codes.  It's not quite a real test of megahit, but since it does test the rule behavior, I figured that was enough.