### PR TITLE
Update conda channel priority during install

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - eclarke
   - louiejtaylor
 dependencies:

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -184,12 +184,16 @@ function test_mapping {
     for file in $TEMPDIR/hosts_*; do
         mv $file ${file/hosts_/hosts\//}
     done
-    # There should be two lines in the human coverage summary and none at all
-    # in the phix174 summary.  The human.csv lines should be sorted in standard
-    # alphanumeric order; stub2_human will come before stub_human.
-    md5sum --check <(
-    echo "c624406eb2582cac5e0cfb160c79a900  $TEMPDIR/sunbeam_output/mapping/human/coverage.csv"
-    echo "1aee435ade0310a6b3c63d44cbdc2029  $TEMPDIR/sunbeam_output/mapping/phix174/coverage.csv"
+    # After the header line, there should be two lines in the human coverage
+    # summary and none at all in the phix174 summary.  The human.csv lines
+    # should be sorted in standard alphanumeric order; stub2_human will come
+    # before stub_human.
+    (
+	    csv_human=$TEMPDIR/sunbeam_output/mapping/human/coverage.csv
+	    csv_phix=$TEMPDIR/sunbeam_output/mapping/phix174/coverage.csv
+	    function col3 { cut -f3 -d, | tr '\n' : ; }
+	    test "Sample:stub2_human:stub_human:" == $(col3 < "$csv_human")
+	    test "Sample:" == $(col3 < "$csv_phix")
     )
 }
 


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully

This switches conda-forge to have a higher priority than bioconda in our environment definition file, matching #181 and [the bioconda instructions](https://bioconda.github.io/#set-up-channels).  @louiejtaylor had previously identified a channel issue that could be resolved in the user's config but it needs to be applied at install-time (fixes #200).  An otherwise unrelated test is updated here as well (test_mapping) so that all tests now pass with the latest available package set.