### PR TITLE
Consider threads for cutadapt in qc

### DIFF
--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -17,6 +17,8 @@ rule adapter_removal_unpaired:
     log: str(QC_FP/'log'/'cutadapt'/'{sample}.log') 
     output:
         str(QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz')
+    threads:
+        Cfg['qc']['threads']
     run:
         fwd_adapters = Cfg['qc'].get('fwd_adapters')
         rev_adapters = Cfg['qc'].get('rev_adapters')
@@ -32,6 +34,7 @@ rule adapter_removal_unpaired:
                     "-g {adapter}", adapter=Cfg['qc']['rev_adapters']))
             shell("""
             cutadapt --discard-trimmed -O {overlap} \
+            --cores {threads} \
             {fwd_adapter_str} {rev_adapter_str} \
             -o {params.tmp} \
             {input} \
@@ -52,6 +55,8 @@ rule adapter_removal_paired:
     output:
         gr1 = str(QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz'),
         gr2 = str(QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz')
+    threads:
+        Cfg['qc']['threads']
     run:
         fwd_adapters = Cfg['qc']['fwd_adapters']
         rev_adapters = Cfg['qc']['rev_adapters']
@@ -67,6 +72,7 @@ rule adapter_removal_paired:
                     "-B {adapter}", adapter=Cfg['qc']['rev_adapters']))
             shell("""
             cutadapt --discard-trimmed -O {overlap} \
+            --cores {threads} \
             {fwd_adapter_str} {rev_adapter_str} \
             -o {params.r1} -p {params.r2} \
             {input.r1} {input.r2} \


### PR DESCRIPTION
Hi,

First of all, thank you for your work, I have just started using sunbeam and it is great and straightforward to use.

I did not find any information on the way to contribute so here is a small PR to take the `threads` parameter set up for `qc` step also by `cutadapt`.

Best regards,
Kenzo

* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [x] ~If this adds a new output file, I have added a check to tests/targets.txt~
* [x] ~If this fixes a bug, I have added an appropriate test to tests/test.sh~
* [x] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`


_edit thanks to @ressy comment_:

Closes #197 