### PR TITLE
Add multiQC to build QC report

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,4 @@ dependencies:
   - rust-bio-tools
   - grabseqs=0.3.4
   - minimap2
+  - multiqc

--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -6,6 +6,12 @@ rule all_qc:
     """Runs trimmomatic and fastqc on all input files."""
     input:
         TARGET_QC
+    params:
+        title = Cfg['qc'].get('report_title', 'QC report'),
+        file_name = Cfg['qc'].get('report_name', 'qc_report.html'),
+        outdir = QC_FP
+    run:
+        shell("multiqc -i \"{params.title}\" -n {params.file_name} -o {params.outdir} {params.outdir}")
 
 ruleorder: adapter_removal_paired > adapter_removal_unpaired
         

--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -6,12 +6,6 @@ rule all_qc:
     """Runs trimmomatic and fastqc on all input files."""
     input:
         TARGET_QC
-    params:
-        title = Cfg['qc'].get('report_title', 'QC report'),
-        file_name = Cfg['qc'].get('report_name', 'qc_report.html'),
-        outdir = QC_FP
-    run:
-        shell("multiqc -i \"{params.title}\" -n {params.file_name} -o {params.outdir} {params.outdir}")
 
 ruleorder: adapter_removal_paired > adapter_removal_unpaired
         
@@ -209,4 +203,16 @@ rule clean_qc:
         rm -r {params.komplexity_fp}
         """
         
+rule multiqc:
+    """Runs multiqc on different logs once every steps are done."""
+    input:
+        TARGET_FASTQC + TARGET_CLEAN
+    output:
+        QC_REPORT
+    params:
+        title = Cfg['qc'].get('report_title', 'QC report'),
+        outdir = QC_FP
+    run:
+        report_name = output[0].split('/')[-1]  # Get unique name from targets.rules file
+        shell("multiqc -i \"{params.title}\" -n {report_name} -o {params.outdir} {params.outdir}")
     

--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -202,17 +202,3 @@ rule clean_qc:
         rm -r {params.trimmomatic_fp} && \
         rm -r {params.komplexity_fp}
         """
-        
-rule multiqc:
-    """Runs multiqc on different logs once every steps are done."""
-    input:
-        TARGET_FASTQC + TARGET_CLEAN
-    output:
-        QC_REPORT
-    params:
-        title = Cfg['qc'].get('report_title', 'QC report'),
-        outdir = QC_FP
-    run:
-        report_name = output[0].split('/')[-1]  # Get unique name from targets.rules file
-        shell("multiqc -i \"{params.title}\" -n {report_name} -o {params.outdir} {params.outdir}")
-    

--- a/rules/reports/reports.rules
+++ b/rules/reports/reports.rules
@@ -44,3 +44,17 @@ rule fastqc_report:
         quality_list = [reports.parse_fastqc_quality(file) for file in input.files]
         quality_table = pandas.concat(quality_list, axis=1).transpose()
         quality_table.to_csv(output[0],sep="\t",index_label="Samples")
+
+
+rule multiqc_report:
+    """Build multiqc report on qc step."""
+    input:
+        TARGET_FASTQC
+    output:
+        MULTIQC_REPORT
+    params:
+        title = Cfg['qc'].get('report_title', 'QC report'),
+        outdir = str(QC_FP/'reports')
+    run:
+        report_name = output[0].split('/')[-1]  # Get unique name from targets.rules file
+        shell("multiqc -i \"{params.title}\" -n {report_name} -o {params.outdir} {params.outdir}")

--- a/rules/targets/targets.rules
+++ b/rules/targets/targets.rules
@@ -13,7 +13,10 @@ TARGET_CLEAN = expand(
     str(QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz'),
     sample = Samples.keys(), rp = Pairs)
 
-TARGET_QC = TARGET_CLEAN + TARGET_FASTQC
+# MultiQC report
+QC_REPORT = str(QC_FP/'qc_report.html')
+
+TARGET_QC = TARGET_CLEAN + TARGET_FASTQC + [QC_REPORT]
 
 # Remove host reads
 TARGET_DECONTAM = expand(

--- a/rules/targets/targets.rules
+++ b/rules/targets/targets.rules
@@ -13,10 +13,7 @@ TARGET_CLEAN = expand(
     str(QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz'),
     sample = Samples.keys(), rp = Pairs)
 
-# MultiQC report
-QC_REPORT = str(QC_FP/'qc_report.html')
-
-TARGET_QC = TARGET_CLEAN + TARGET_FASTQC + [QC_REPORT]
+TARGET_QC = TARGET_CLEAN + TARGET_FASTQC
 
 # Remove host reads
 TARGET_DECONTAM = expand(
@@ -59,12 +56,15 @@ TARGET_ANNOTATE = expand(
 
 
 # ---- Reports
+# MultiQC report
+MULTIQC_REPORT = str(QC_FP/'reports'/'multiqc_report.html')
+
 TARGET_REPORT = [
     str(QC_FP/'reports'/'preprocess_summary.tsv'),
     str(QC_FP/'reports'/'fastqc_quality.tsv'),
-    str(ASSEMBLY_FP/'contigs_coverage.txt')
+    str(ASSEMBLY_FP/'contigs_coverage.txt'),
+    MULTIQC_REPORT
 ]
-
 
 # ---- All targets
 TARGET_ALL = (

--- a/sunbeamlib/scripts/init.py
+++ b/sunbeamlib/scripts/init.py
@@ -133,7 +133,7 @@ def write_samples_from_input(args, project_fp):
             except MissingMatePairError as e:
                 raise SystemExit(
                     "Error: assuming paired-end reads, but could not find mates. Specify "
-                    "--single-end if not paired-end, or provide sample name format "
+                    "--single_end if not paired-end, or provide sample name format "
                     "using --format."
                     "\n  Reason: {}".format(e))
             sys.stderr.write(

--- a/tests/targets.txt
+++ b/tests/targets.txt
@@ -31,7 +31,7 @@ qc/cleaned/dummyecoli_2.fastq.gz
 qc/cleaned/random_1.fastq.gz
 qc/cleaned/random_2.fastq.gz
 
-qc/qc_report.html
+qc/reports/multiqc_report.html
 
 mapping/human/coverage.csv
 mapping/phix174/coverage.csv

--- a/tests/targets.txt
+++ b/tests/targets.txt
@@ -31,5 +31,7 @@ qc/cleaned/dummyecoli_2.fastq.gz
 qc/cleaned/random_1.fastq.gz
 qc/cleaned/random_2.fastq.gz
 
+qc/qc_report.html
+
 mapping/human/coverage.csv
 mapping/phix174/coverage.csv


### PR DESCRIPTION
## Description

As promised, here is another PR, more as a POC for the use of [MultiQC](https://multiqc.info/) in the `qc` step.

In the future, if the rule is also used in other steps to get a summary of them, I guess we could put it in an independant `.rules` file and include this generalized rules in every concerned step.

Since a new rule is here added and I was not sure on the way to proceed, I apologize in advance if I put things in the incorrect place or named variable without respecting your own development rules.

## Validations

* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [x] If this adds a new output file, I have added a check to tests/targets.txt
* [x] ~If this fixes a bug, I have added an appropriate test to tests/test.sh~
* [x] ~If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`~

Cheers,
Kenzo
