### PR TITLE
update snakemake for newer versions of conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - eclarke
   - louiejtaylor
 dependencies:
-  - snakemake=4.8.1
+  - snakemake
   - ruamel.yaml
   - biopython
   - trimmomatic=0.36

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - eclarke
   - louiejtaylor
 dependencies:
-  - snakemake
+  - snakemake=5.5.0
   - ruamel.yaml
   - biopython
   - trimmomatic=0.36

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -48,6 +48,11 @@ function test_extensions {
     sunbeam run --configfile $TEMPDIR/tmp_config.yml sbx_test | grep "SBX_TEST"
 }
 
+# Test that we have the updated snakemake that uses "conda activate"
+function test_use_conda {
+    sunbeam run --configfile $TEMPDIR/tmp_config.yml --use-conda sbx_test | grep "SBX_TEST"
+}
+
 # Test that single-end sequencing configurations work
 function test_single_end {
     rm -rf $TEMPDIR/sunbeam_output/qc


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [NA] If this adds a new output file, I have added a check to tests/targets.txt
* [x] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [NA] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

-Made environment.yml get the latest version of snakemake which works with the latest version of conda (otherwise, when you run any extension that has --use-conda, it will fail when it tries "source activate")
-Added test for "--use-conda"

