### PR TITLE
Specify longer CircleCI output timeout during install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
           name: install
           command: |
             bash install.sh -u lib -e sunbeam
+          no_output_timeout: 20m
 
       - run:
           name: run tests


### PR DESCRIPTION
This is just a change to the CircleCI configuration to extend the timeout waiting for output during the install step, but I'd like to merge this into stable directly so we don't get false positives during testing.  Fixes #210.