### PR TITLE
Require megahit <1.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - bwa>=0.7.17
   - pysam
   - pandas
-  - megahit<2
+  - megahit<1.2
   - prodigal
   - semantic_version
   - setuptools_scm

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - bwa>=0.7.17
   - pysam
   - pandas
-  - megahit
+  - megahit<2
   - prodigal
   - semantic_version
   - setuptools_scm

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -3,7 +3,14 @@ function test_all {
     sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p
 
     # Check contents
-    awk '/NC_000913.3|\t2/  {rc = 1; print}; END { exit !rc }' $TEMPDIR/sunbeam_output/annotation/summary/dummyecoli.tsv
+    annot_summary=sunbeam_output/annotation/summary/dummyecoli.tsv
+    awk '/NC_000913.3|\t2/  {rc = 1; print}; END { exit !rc }' $TEMPDIR/$annot_summary || (
+        # stderr will show up on the summary output for the test suite as well
+        # as in the .err file.  false will cause the shell to exit assuming -e
+        # is in effect here.
+        echo "Check failed on $annot_summary" > /dev/stderr
+        false
+    )
 
     # Check targets
     python tests/find_targets.py --prefix $TEMPDIR/sunbeam_output tests/targets.txt 


### PR DESCRIPTION
This updates the conda environment file to require megahit below version 1.2.  I also added en explicit error message for a related test failure in test_all.  This fixes #213.  I'd like to merge this straight into stable so new installs work as expected again; we can then update and finish off #204 and sync it all back with dev too.