### PR TITLE
Sunbeam version 2.0.1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,12 @@ More extensions can be found at the extension page: https://www.sunbeam-labs.org
 
 ### Changelog:
 
+#### v2.0.1 (July 24, 2019)
+
+ - Increment Snakemake version requirement for compatibility with recent conda
+ - Specify earlier megahit version to ensure compatbility with existing assembly behavior
+ - Integration test improvements
+
 #### v2.0.0 (January 22, 2019)
 
  - Start a project using resources directly from the SRA using `sunbeam init --data_acc [SRA ###]`. For more information, see [the docs](https://sunbeam.readthedocs.io/en/latest/usage.html#creating-a-new-project-using-data-from-sra)

--- a/Readme.md
+++ b/Readme.md
@@ -28,12 +28,21 @@ Sunbeam was designed to be modular and extensible. Some extensions have been bui
 - [Kaiju](https://github.com/sunbeam-labs/sbx_kaiju), a read classifier that uses BWA rather than kmers
 - [Anvi'o](https://github.com/sunbeam-labs/sbx_anvio), a downstream analysis pipeline that does lots of stuff!
 
-To get started, see our [documentation](http://sunbeam.readthedocs.io)!
+More extensions can be found at the extension page: https://www.sunbeam-labs.org/
+
+**To get started, see our [documentation](http://sunbeam.readthedocs.io)!**
 
 
 ------
 
 ### Changelog:
+
+#### v2.0.0 (January 22, 2019)
+
+ - Start a project using resources directly from the SRA using `sunbeam init --data_acc [SRA ###]`. For more information, see [the docs](https://sunbeam.readthedocs.io/en/latest/usage.html#creating-a-new-project-using-data-from-sra)
+ - New extension website: https://www.sunbeam-labs.org/
+ - Improved documentation
+ - Numerous bugfixes and optimizations
 
 #### v1.2.1 (May 24, 2018)
 
@@ -72,4 +81,5 @@ To get started, see our [documentation](http://sunbeam.readthedocs.io)!
 - Chunyu Zhao ([@zhaoc1](https://github.com/zhaoc1))
 - Jesse Connell ([@ressy](https://github.com/ressy))
 - Louis Taylor ([@louiejtaylor](https://github.com/louiejtaylor))
+- Kyle Bittinger ([@kylebittinger](https://github.com/kylebittinger))
 


### PR DESCRIPTION
I'm proposing naming the recent package-version hotfixes as 2.0.1.  Those commits went in separately so this just updates the changelog to match and gives a verified commit to tie to the tag + release.

Specifically it covers:

 * megahit < 1.2 (#216)
 * snakemake=5.5.0 (#204/#215)
 * Minor CircleCI configuration change (#211)