### PR TITLE
add h5py to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,3 +27,4 @@ dependencies:
   - grabseqs=0.3.4
   - minimap2
   - multiqc
+  - h5py # temp: patching missing dependency of biom-format (req'd by kraken-biom)


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully

This is a quick fix for #214, which failed at kraken result processing post-classification. See #214 for an in-depth discussion of the issue and long-term plans.