### PR TITLE
Use "conda activate" instead of "source activate"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,6 @@
 
 __conda_url=https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 
-CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
-source $CONDA_BASE/etc/profile.d/conda.sh # allows conda [de]activate in scripts
-
 read -r -d '' __usage <<-'EOF'
   -e --environment  [arg] Environment to install to. Default: "sunbeam"
   -s --sunbeam_dir  [arg] Location of Sunbeam source code. Default: this directory
@@ -186,6 +183,10 @@ else
     install_conda
     __env_changed=true
 fi
+
+# Allow conda [de]activate in this script
+CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
+source $CONDA_BASE/etc/profile.d/conda.sh
 
 # Create Conda environment for Sunbeam
 if [[ $__env_exists = true && $__update_env = false ]]; then

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,9 @@
 
 __conda_url=https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 
+CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
+source $CONDA_BASE/etc/profile.d/conda.sh # allows conda [de]activate in scripts
+
 read -r -d '' __usage <<-'EOF'
   -e --environment  [arg] Environment to install to. Default: "sunbeam"
   -s --sunbeam_dir  [arg] Location of Sunbeam source code. Default: this directory
@@ -109,13 +112,13 @@ function __test_sunbeam() {
 
 function activate_sunbeam () {
     set +o nounset
-    source activate $__sunbeam_env
+    conda activate $__sunbeam_env
     set -o nounset
 }
 
 function deactivate_sunbeam () {
     set +o nounset
-    source deactivate
+    conda deactivate
     set -o nounset
 }
 
@@ -220,9 +223,9 @@ if [[ $__old_path != *"${__conda_path}/bin"* ]]; then
     warning "To add it to your path, run "
     warning "   'echo \"export PATH=\$PATH:${__conda_path}/bin\" >> ~/.bashrc'"
     warning "and close and re-open your terminal session to apply."
-    warning "When finished, run 'source activate ${__sunbeam_env}' to begin."
+    warning "When finished, run 'conda activate ${__sunbeam_env}' to begin."
 else
-    info "Done. Run 'source activate ${__sunbeam_env}' to begin."
+    info "Done. Run 'conda activate ${__sunbeam_env}' to begin."
 fi
 
    

--- a/install.sh
+++ b/install.sh
@@ -99,9 +99,6 @@ function __test_env() {
 
 function __test_sunbeam() {
     if [[ $(__test_env) = true ]]; then
-        # Allow conda [de]activate in this script
-        CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
-        source $CONDA_BASE/etc/profile.d/conda.sh
 	activate_sunbeam
 	command -v sunbeam &> /dev/null && echo true || echo false
 	deactivate_sunbeam
@@ -110,13 +107,21 @@ function __test_sunbeam() {
     fi
 }
 
+function enable_conda_activate () {
+    # Allow conda [de]activate in this script
+    CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
+    source $CONDA_BASE/etc/profile.d/conda.sh
+}
+
 function activate_sunbeam () {
+    enable_conda_activate
     set +o nounset
     conda activate $__sunbeam_env
     set -o nounset
 }
 
 function deactivate_sunbeam () {
+    enable_conda_activate
     set +o nounset
     conda deactivate
     set -o nounset
@@ -186,10 +191,6 @@ else
     install_conda
     __env_changed=true
 fi
-
-# Allow conda [de]activate in this script
-CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
-source $CONDA_BASE/etc/profile.d/conda.sh
 
 # Create Conda environment for Sunbeam
 if [[ $__env_exists = true && $__update_env = false ]]; then

--- a/install.sh
+++ b/install.sh
@@ -99,6 +99,9 @@ function __test_env() {
 
 function __test_sunbeam() {
     if [[ $(__test_env) = true ]]; then
+        # Allow conda [de]activate in this script
+        CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
+        source $CONDA_BASE/etc/profile.d/conda.sh
 	activate_sunbeam
 	command -v sunbeam &> /dev/null && echo true || echo false
 	deactivate_sunbeam
@@ -185,7 +188,6 @@ else
 fi
 
 # Allow conda [de]activate in this script
-conda init bash
 CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
 source $CONDA_BASE/etc/profile.d/conda.sh
 

--- a/install.sh
+++ b/install.sh
@@ -185,6 +185,7 @@ else
 fi
 
 # Allow conda [de]activate in this script
+conda init bash
 CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
 source $CONDA_BASE/etc/profile.d/conda.sh
 

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -1,8 +1,13 @@
 #!/bin/bash
 
+# setup
+
 set -e
 
 STARTING_DIR=$(pwd)
+
+CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
+source $CONDA_BASE/etc/profile.d/conda.sh # allows conda [de]activate in scripts
 
 # Ensure we're running in the correct directory
 case $BASH_SOURCE in
@@ -128,7 +133,7 @@ function setup {
     verbose "\n\t${GREEN}Conda environment${RESET}: ${SUNBEAM_ENV}\n"
 
     # Activate Sunbeam
-    source activate $SUNBEAM_ENV
+    conda activate $SUNBEAM_ENV
 
     # Move extensions out of the way temporarily
     if [ -d $SBX_FP ]; then
@@ -156,7 +161,7 @@ function cleanup {
 	    [ -f "${LOGFILE}.out" ] && rm "${LOGFILE}.out"
 	fi
     fi
-    source deactivate
+    conda deactivate
     # Remove Sunbeam environment if created
     if [ "$INSTALL_SUNBEAM" = true ]; then
 	verbose "Deleting temporary Sunbeam environment ${SUNBEAM_ENV} \n"

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -6,9 +6,6 @@ set -e
 
 STARTING_DIR=$(pwd)
 
-CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
-source $CONDA_BASE/etc/profile.d/conda.sh # allows conda [de]activate in scripts
-
 # Ensure we're running in the correct directory
 case $BASH_SOURCE in
     tests/*)
@@ -123,7 +120,10 @@ function setup {
     verbose "\n\t${GREEN}Test directory${RESET}: ${TEMPDIR}"
 
     export PATH=$PATH:$HOME/miniconda3/bin
-    
+    # Allow conda [de]activate
+    CONDA_BASE=$(conda info --base) # see https://github.com/conda/conda/issues/7980
+    source $CONDA_BASE/etc/profile.d/conda.sh
+
     # Install Sunbeam (maybe)
     if [ "$USE_TMPENV" = true ]; then
 	SUNBEAM_ENV="sunbeam-`basename $TEMPDIR`"


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully

This PR is related to issue #198 (and was also brought up in #204 by @scottdaniel). Now the install and test scripts use "conda [de]activate" rather than "source [de]activate". No more warnings!