### PR TITLE
Schedule weekly build in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ workflows:
           filters:
             branches:
               only:
-                - ci
                 - dev
                 - stable
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,6 @@ workflows:
           filters:
             branches:
               only:
-                - circleci-improvements
+                - ci
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,16 @@ jobs:
           paths:
             - ~/miniconda3
           key: v1-dependencies-{{ checksum "environment.yml" }}
-           
+
+workflows:
+  version: 2
+  dailybuild:
+    triggers:
+      - schedule:
+          cron: "30 14 * * *"
+          filters:
+            branches:
+              only:
+                - circleci-improvements
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,13 +35,15 @@ jobs:
 
 workflows:
   version: 2
-  dailybuild:
+  weeklybuild:
     triggers:
       - schedule:
-          cron: "30 14 * * *"
+          cron: "30 14 * * 3"
           filters:
             branches:
               only:
                 - ci
+                - dev
+                - stable
     jobs:
       - build


### PR DESCRIPTION
This is a change to the test configuration only, to schedule an automatic weekly build in CircleCI for dev and stable.  I figure this should help us catch dependency/version-related problems even if we haven't changed anything lately.