### PR TITLE
Add support for sequence IDs with read suffix (Old Illumina)

### DIFF
--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -2,16 +2,31 @@
 #
 # Illumina quality control rules
 
+from sunbeamlib import qc
+
 rule all_qc:
     """Runs trimmomatic and fastqc on all input files."""
     input:
         TARGET_QC
 
 ruleorder: adapter_removal_paired > adapter_removal_unpaired
-        
+
+rule sample_intake:
+    input:
+        lambda wildcards: Samples[wildcards.sample][wildcards.rp]
+    output:
+        str(QC_FP/'00_samples'/'{sample}_{rp}.fastq.gz')
+    params:
+        suffix = Cfg['qc'].get('seq_id_ending')
+    run:
+        if params.suffix:
+            qc.strip_seq_id_suffix(input[0], output[0], params.suffix)
+        else:
+            Path(output[0]).symlink_to(input[0])
+
 rule adapter_removal_unpaired:
     input:
-        lambda wildcards: Samples[wildcards.sample]['1']
+        str(QC_FP/'00_samples'/'{sample}_1.fastq.gz')
     params:
         tmp = str(QC_FP/'01_cutadapt'/'{sample}_1.fastq'),
     log: str(QC_FP/'log'/'cutadapt'/'{sample}.log') 
@@ -46,8 +61,8 @@ rule adapter_removal_unpaired:
     
 rule adapter_removal_paired:
     input:
-        r1 = lambda wildcards: Samples[wildcards.sample]['1'],
-        r2 = lambda wildcards: Samples[wildcards.sample]['2']
+        r1 = str(QC_FP/'00_samples'/'{sample}_1.fastq.gz'),
+        r2 = str(QC_FP/'00_samples'/'{sample}_2.fastq.gz')
     params:
         r1 = str(QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz'),
         r2 = str(QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz')

--- a/sunbeamlib/qc.py
+++ b/sunbeamlib/qc.py
@@ -1,0 +1,31 @@
+"""
+Supporting functions for QC rules.
+"""
+
+import gzip
+import re
+from Bio import SeqIO
+
+def strip_seq_id_suffix(fp_in, fp_out, suffix_pattern):
+    """Remove sequence ID suffix from entries in a FASTQ file.
+
+    fp_in: path to input FASTQ
+    fp_out: path to output FASTQ
+    suffix_pattern: regular expression for suffix to remove, e.g., "/[12]".
+    This will be anchored to the end of the ID string.
+    """
+    try:
+        if fp_in.endswith(".gz"):
+            f_in = gzip.open(fp_in, "rt")
+        else:
+            f_in = open(fp_in, "rU")
+        if fp_out.endswith(".gz"):
+            f_out = gzip.open(fp_out, "wt")
+        else:
+            f_out = open(fp_out, "w")
+        for record in SeqIO.parse(f_in, "fastq"):
+            record.id = re.sub(suffix_pattern + "$", "", record.id)
+            SeqIO.write(record, f_out, "fastq")
+    finally:
+        f_in.close()
+        f_out.close()

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -196,6 +196,7 @@ function build_test_data {
     mkdir -p $TEMPDIR/hosts
     cp indexes/*.fasta $TEMPDIR/hosts
     python generate_dummy_data.py $TEMPDIR
+    python generate_dummy_data.py $TEMPDIR data_files_old_illumina /1 /2
     # Create a version of the config file customized for this tempdir
     sunbeam init \
 	    --force \

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -18,15 +18,20 @@ function test_all {
 
 # For #221: full test using old-style Illumina paired sequence IDs (/1 and /2)
 function test_all_old_illumina {
+    # init will always write to samples.csv so we'll stash the old one and then
+    # restore it.
+    mv $TEMPDIR/samples.csv $TEMPDIR/samples_orig.csv
     sunbeam init \
             --force \
             --output tmp_config_old_illumina.yml \
-            --defaults <(
-                sed s/sunbeam_output/sunbeam_output_old_illumina/ $TEMPDIR/tmp_config.yml
-                ) \
+            --defaults <(sed s/sunbeam_output/sunbeam_output_old_illumina/ $TEMPDIR/tmp_config.yml) \
             --data_fp $TEMPDIR/data_files_old_illumina \
             $TEMPDIR
+    # Add config entry for suffix to remove from sequence IDs, and run just
+    # like before.
+    sed -i 's/^qc:/qc:\n  seq_id_ending: "\/[12]"/' $TEMPDIR/tmp_config_old_illumina.yml
     sunbeam run -- --configfile=$TEMPDIR/tmp_config_old_illumina.yml -p
+    mv $TEMPDIR/samples_orig.csv $TEMPDIR/samples.csv
 
     # Check contents
     annot_summary=sunbeam_output_old_illumina/annotation/summary/dummyecoli.tsv

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -16,6 +16,31 @@ function test_all {
     python tests/find_targets.py --prefix $TEMPDIR/sunbeam_output tests/targets.txt 
 }
 
+# For #221: full test using old-style Illumina paired sequence IDs (/1 and /2)
+function test_all_old_illumina {
+    sunbeam init \
+            --force \
+            --output tmp_config_old_illumina.yml \
+            --defaults <(
+                sed s/sunbeam_output/sunbeam_output_old_illumina/ $TEMPDIR/tmp_config.yml
+                ) \
+            --data_fp $TEMPDIR/data_files_old_illumina \
+            $TEMPDIR
+    sunbeam run -- --configfile=$TEMPDIR/tmp_config_old_illumina.yml -p
+
+    # Check contents
+    annot_summary=sunbeam_output_old_illumina/annotation/summary/dummyecoli.tsv
+    awk '/NC_000913.3|\t2/  {rc = 1; print}; END { exit !rc }' $TEMPDIR/$annot_summary || (
+        # stderr will show up on the summary output for the test suite as well
+        # as in the .err file.  false will cause the shell to exit assuming -e
+        # is in effect here.
+        echo "Check failed on $annot_summary" > /dev/stderr
+        false
+    )
+
+    # Check targets
+    python tests/find_targets.py --prefix $TEMPDIR/sunbeam_output_old_illumina tests/targets.txt
+}
 
 # Fix for #38: Make Cutadapt optional
 # Remove adapter sequences and check to make sure qc proceeds correctly


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [X] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [X] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

This changes the graph at the very start of the QC rules to optionally strip off a configurable suffix for sequence IDs, to ensure that pairs always use the same ID, as generally expected.  Fixes #221.  (If this feature isn't enabled it will just symlink the original files into place instead.)  This allows us to work with older-style Illumina sequence IDs that end with /1 and /2 for R1 and R2, or any other suffix pattern that might be used.