### PR TITLE
Add seq_id_ending to default configuration

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -230,9 +230,10 @@ qc
 * ``suffix``: the name of the subfolder to hold outputs from the
   quality-control steps
 * ``threads``: the number of threads to use for rules in this section
-* ``seq_id_ending``: if your reads are named differently, a string defining the
-  suffix. For example, if your paired read ids are ``@D00728:28:C9W1KANXX:0/1`` and 
-  ``@D00728:28:C9W1KANXX:0/2``, this entry of your config file would be: 
+* ``seq_id_ending``: if your reads are named differently, a regular expression
+  string defining the pattern of the suffix. For example, if your paired read
+  ids are ``@D00728:28:C9W1KANXX:0/1`` and ``@D00728:28:C9W1KANXX:0/2``, this
+  entry of your config file would be:
   ``seq_id_ending: "/[12]"``
 * ``java_heapsize``: the memory available to Trimmomatic
 * ``leading``: (trimmomatic) remove the leading bases of a read if below this

--- a/rules/qc/qc.rules
+++ b/rules/qc/qc.rules
@@ -17,7 +17,7 @@ rule sample_intake:
     output:
         str(QC_FP/'00_samples'/'{sample}_{rp}.fastq.gz')
     params:
-        suffix = Cfg['qc'].get('seq_id_ending')
+        suffix = Cfg['qc']['seq_id_ending']
     run:
         if params.suffix:
             qc.strip_seq_id_suffix(input[0], output[0], params.suffix)

--- a/sunbeamlib/data/default_config.yml
+++ b/sunbeamlib/data/default_config.yml
@@ -28,6 +28,8 @@ all:
 # Quality control
 qc:
   suffix: qc
+  # Sample intake
+  seq_id_ending: ""
   # Trimmomatic
   threads: 4
   java_heapsize: 512M

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -29,7 +29,7 @@ function test_all_old_illumina {
             $TEMPDIR
     # Add config entry for suffix to remove from sequence IDs, and run just
     # like before.
-    sed -i 's/^qc:/qc:\n  seq_id_ending: "\/[12]"/' $TEMPDIR/tmp_config_old_illumina.yml
+    sed -i 's/^  seq_id_ending: ""$/  seq_id_ending: "\/[12]"/' $TEMPDIR/tmp_config_old_illumina.yml
     sunbeam run -- --configfile=$TEMPDIR/tmp_config_old_illumina.yml -p
     mv $TEMPDIR/samples_orig.csv $TEMPDIR/samples.csv
 

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -29,7 +29,7 @@ function test_all_old_illumina {
             $TEMPDIR
     # Add config entry for suffix to remove from sequence IDs, and run just
     # like before.
-    sed -i 's/^  seq_id_ending: ""$/  seq_id_ending: "\/[12]"/' $TEMPDIR/tmp_config_old_illumina.yml
+    sed -i -r 's/^( +seq_id_ending: *).*$/\1"\/[12]"/' $TEMPDIR/tmp_config_old_illumina.yml
     sunbeam run -- --configfile=$TEMPDIR/tmp_config_old_illumina.yml -p
     mv $TEMPDIR/samples_orig.csv $TEMPDIR/samples.csv
 


### PR DESCRIPTION
This finalizes the new sequence ID normalizing feature (See #238) by adding it to the default configuration file, and expands on one point in the usage documentation.  Fixes #244.