### PR TITLE
remove jellyfish from env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,6 @@ dependencies:
   - kraken2
   - kraken-biom
   - vsearch
-  - jellyfish=1.1.11=1
   - cutadapt
   - bwa>=0.7.17
   - pysam


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully

Quick PR to remove the pinned jellyfish dependency before trying to figure out what's gone wrong with the merge of `sunbeam extend`
