### PR TITLE
Easier installation for extensions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,8 +42,9 @@ sequencing experiments. *Microbiome* 7:46 (2019)
 
 ### Changelog:
 
-#### Development version (as of November 26, 2019)
+#### Development version (as of December 2, 2019)
 
+ - New command `sunbeam extend` to automatically install Sunbeam extensions! Use like `sunbeam extend https://github.com/sunbeam-labs/sbx_report`
  - `sunbeam init` and `sunbeam config update` now add options for extensions you've installed to your default config file! (#247)
  - Updated the path to the Illumina adapter sequences from hardcoded to templated (fixes #150 and #152)
  - Use the updated kraken2 classifier instead of kraken

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -21,6 +21,13 @@ files to facilitate the installation of software dependencies, to
 specify parameters in the configuration file, and to give instructions
 to users.
 
+In Sunbeam version 3.0 and higher, extensions can be installed using the
+``sunbeam extend`` command, followed by the GitHub URL of the 
+extension you're installing. For example, to install an extension to
+run the kaiju classifier, you would run::
+
+    sunbeam extend https://github.com/sunbeam-labs/sbx_kaiju/
+
 Sunbeam extensions are installed by placing the extension directory in
 the ``extensions/`` subdirectory of the Sunbeam software.  Once the
 extension is in place, Sunbeam will find the *rules* file and

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -102,6 +102,17 @@ If things go awry and updating doesn't work, simply uninstall and reinstall Sunb
 
 Then follow the installation_ instructions above.
 
+Installing Sunbeam extensions
+-----------------------------
+
+As of version 3.0, Sunbeam extensions can be installed by running ``sunbeam extend``
+followed by the URL of the extension's GitHub repo::
+
+    sunbeam extend https://github.com/sunbeam-labs/sbx_kaiju/
+
+For Sunbeam versions prior to 3.0, follow the instructions on the extension to 
+install.
+
 Setup
 =====
 

--- a/environment.yml
+++ b/environment.yml
@@ -29,3 +29,4 @@ dependencies:
   - h5py # temp: patching missing dependency of biom-format (req'd by kraken-biom)
   - samtools>=1.9
   - bcftools>=1.9
+  - git

--- a/sunbeamlib/config.py
+++ b/sunbeamlib/config.py
@@ -152,7 +152,7 @@ def extension_config():
             # append it to the existing config
             sbx_config_fp = sunbeam_dir/"extensions"/sbx/"config.yml"
             sbx_configfile = open(sbx_config_fp)
-            sbx_config = "\n"+sbx_configfile.read()+"\n"
+            sbx_config = "\n"+sbx_configfile.read()
             sbx_configfile.close() 
             config = str(config + sbx_config)
     return config

--- a/sunbeamlib/scripts/command.py
+++ b/sunbeamlib/scripts/command.py
@@ -6,6 +6,7 @@ from sunbeamlib.scripts.run import main as Run
 from sunbeamlib.scripts.init import main as Init
 from sunbeamlib.scripts._config import main as Config
 from sunbeamlib.scripts.list_samples import main as ListSamples
+from sunbeamlib.scripts.extend import main as Extend
 
 def main():
 
@@ -42,6 +43,8 @@ def main():
         Config(remaining)
     elif args.command == "list_samples":
         ListSamples(remaining)
+    elif args.command == "extend":
+        Extend(remaining)
     else:
         parser.print_help()
         sys.stderr.write("Unrecognized command.\n")

--- a/sunbeamlib/scripts/extend.py
+++ b/sunbeamlib/scripts/extend.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import argparse
+import subprocess
+from pathlib import Path
+
+def main(argv=sys.argv):
+
+    parser = argparse.ArgumentParser(
+        "sunbeam extend",
+        usage="%(prog)s github_url",
+        description="Installs a Sunbeam extension from the given GitHub URL.",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument(
+        "github_url", type = str,
+        help="URL to Sunbeam extension on GitHub (e.g. https://github.com/sunbeam-labs/sbx_report")
+
+    parser.add_argument(
+        "-s", "--sunbeam_dir", default=os.getenv("SUNBEAM_DIR", os.getcwd()),
+        help="Path to Sunbeam installation")
+
+    args = parser.parse_args(argv)
+    
+    extensions_dir = Path(args.sunbeam_dir)/"extensions"
+    if not extensions_dir.exists():
+        sys.stderr.write(
+            "Error: could not find an extensions directory in '{}'\n".format(
+                args.sunbeam_dir))
+        sys.exit(1)
+
+    extension_name = args.github_url.split("/")[-1]
+    if extension_name.endswith(".git"):
+        extension_name = extension_name[:-4]
+
+    git_clone_args = ["git","clone",args.github_url,str(extensions_dir/extension_name)]
+
+    print("Installing: "+extension_name+" from "+args.github_url)
+
+    cmd = subprocess.run(git_clone_args)
+    
+    sys.exit(cmd.returncode)

--- a/sunbeamlib/scripts/extend.py
+++ b/sunbeamlib/scripts/extend.py
@@ -35,7 +35,7 @@ def main(argv=sys.argv):
 
     git_clone_args = ["git","clone",args.github_url,str(extensions_dir/extension_name)]
 
-    print("Installing: "+extension_name+" from "+args.github_url)
+    sys.stderr.write("Installing "+extension_name+" from "+args.github_url)
 
     cmd = subprocess.run(git_clone_args)
     

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -360,3 +360,21 @@ function test_extension_config_update {
     echo "sbx_test found in config" `cat $TEMPDIR/tmp_config_extension_config_update.yml | grep "sbx_test:"` "time(s)"
     test `cat $TEMPDIR/tmp_config_extension_config_update.yml | grep "sbx_test:" | wc -l` -eq 1
 }
+
+# For #251: test sunbeam extend
+
+function test_all_sunbeam_extend {
+
+    sunbeam extend https://github.com/sunbeam-labs/sbx_report
+
+    sunbeam init \
+        --force \
+        --output tmp_config_extended.yml \
+        --data_fp $TEMPDIR/data_files \
+        $TEMPDIR
+
+    sunbeam run --use-conda --configfile=$TEMPDIR/tmp_config_extended.yml -p final_report
+
+    test `ls $TEMPDIR/sunbeam_output/reports/ | grep "final_report.html" | wc -l` -eq 1
+
+}

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -367,13 +367,9 @@ function test_all_sunbeam_extend {
 
     sunbeam extend https://github.com/sunbeam-labs/sbx_coassembly
 
-    sunbeam init \
-        --force \
-        --output tmp_config_extended.yml \
-        --data_fp $TEMPDIR/data_files \
-        $TEMPDIR
+    sunbeam config update -i $TEMPDIR/tmp_config.yml
 
-    sunbeam run --use-conda --configfile=$TEMPDIR/tmp_config_extended.yml -p all_coassemble
+    sunbeam run --use-conda --configfile=$TEMPDIR/tmp_config.yml -p all_coassemble
 
     test `ls $TEMPDIR/sunbeam_output/assembly | grep "coassembly" | wc -l` -eq 1
 

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -365,7 +365,7 @@ function test_extension_config_update {
 
 function test_all_sunbeam_extend {
 
-    sunbeam extend https://github.com/sunbeam-labs/sbx_report
+    sunbeam extend https://github.com/sunbeam-labs/sbx_coassembly
 
     sunbeam init \
         --force \
@@ -373,8 +373,8 @@ function test_all_sunbeam_extend {
         --data_fp $TEMPDIR/data_files \
         $TEMPDIR
 
-    sunbeam run --use-conda --configfile=$TEMPDIR/tmp_config_extended.yml -p final_report
+    sunbeam run --use-conda --configfile=$TEMPDIR/tmp_config_extended.yml -p all_coassemble
 
-    test `ls $TEMPDIR/sunbeam_output/reports/ | grep "final_report.html" | wc -l` -eq 1
+    test `ls $TEMPDIR/sunbeam_output/assembly | grep "coassembly" | wc -l` -eq 1
 
 }


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully

This PR (re)introduces a new subcommand: `sunbeam extend`, which installs Sunbeam extensions from a GitHub repository URL. The `sunbeam extend` logic is encapsulated in the new file `sunbeamlib/scripts/extend.py `. Other inclusions: new test, README update, documentation updates describing this new feature. Related to #251.