### PR TITLE
Handle trailing slash in url passed to `sunbeam extend`

### DIFF
--- a/sunbeamlib/scripts/extend.py
+++ b/sunbeamlib/scripts/extend.py
@@ -28,14 +28,19 @@ def main(argv=sys.argv):
             "Error: could not find an extensions directory in '{}'\n".format(
                 args.sunbeam_dir))
         sys.exit(1)
-
-    extension_name = [p for p in args.github_url.split("/") if len(p) > 0][-1]
+    
+    # handle odd github url formats that make `git clone` mad
+    gh_url = args.github_url.strip()
+    if gh_url.endswith('/'):
+        gh_url = gh_url[:-1]
+    extension_name = gh_url.split("/")[-1]
+    
     if extension_name.endswith(".git"):
         extension_name = extension_name[:-4]
 
-    git_clone_args = ["git","clone",args.github_url,str(extensions_dir/extension_name)]
+    git_clone_args = ["git","clone",gh_url,str(extensions_dir/extension_name)]
 
-    sys.stderr.write("Installing "+extension_name+" from "+args.github_url)
+    sys.stderr.write("Installing "+extension_name+" from "+gh_url+"\n")
 
     cmd = subprocess.run(git_clone_args)
     

--- a/sunbeamlib/scripts/extend.py
+++ b/sunbeamlib/scripts/extend.py
@@ -29,7 +29,7 @@ def main(argv=sys.argv):
                 args.sunbeam_dir))
         sys.exit(1)
 
-    extension_name = args.github_url.split("/")[-1]
+    extension_name = [p for p in args.github_url.split("/") if len(p) > 0][-1]
     if extension_name.endswith(".git"):
         extension_name = extension_name[:-4]
 

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -379,8 +379,8 @@ function test_all_sunbeam_extend {
 
 function test_extend_trailing_slash {
 
-    sunbeam extend https://github.com/sunbeam-labs/sbx_subsample/
+    sunbeam extend https://github.com/sunbeam-labs/sbx_metaphlan/
 
-    ls $SUNBEAM_DIR/extensions/sbx_subsample/
+    rm -rf $SUNBEAM_DIR/extensions/sbx_metaphlan/
 
 }

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -374,3 +374,13 @@ function test_all_sunbeam_extend {
     test `ls $TEMPDIR/sunbeam_output/assembly | grep "coassembly" | wc -l` -eq 1
 
 }
+
+# For #261: handle URLs with a traling slash
+
+function test_extend_trailing_slash {
+
+    sunbeam extend https://github.com/sunbeam-labs/sbx_subsample/
+
+    ls $SUNBEAM_DIR/extensions/sbx_subsample/
+
+}


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [x] If this fixes a bug, I have added an appropriate test to tests/test.sh

Quick bugfix for `sunbeam extend`. This bug is described in, and this commit fixes #261.