### PR TITLE
added sanity check to warn against installing from a .tar.gz git archive, which raises a setuptools_scm error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,14 @@ fi
 __old_path=$PATH
 PATH=$PATH:${__conda_path}/bin
 
+function __git_dir_exists() {
+    if [ -d ".git" ]; then
+      echo true
+    else
+      echo false
+    fi
+}
+
 function __test_conda() {
     command -v conda &> /dev/null && echo true || echo false
 }
@@ -157,6 +165,10 @@ function install_env_vars () {
 
 function install_sunbeamlib () {
     activate_sunbeam
+    if [[ $(__git_dir_exists) != true ]]; then
+      installation_error "Sunbeam requires a git clone \
+(instead of a compressed archive) to detect its version"
+    fi
     debug_capture pip install --upgrade $__sunbeam_dir 2>&1
     if [[ $(__test_sunbeam) != true ]]; then
 	installation_error "Library installation"


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

This attempts to address a confusing situation (at least for me) when trying to install Sunbeam from a git archive instead of a clone of the repo