### PR TITLE
Add explicit blis depencency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,3 +29,4 @@ dependencies:
   - samtools>=1.9
   - bcftools>=1.9
   - git
+  - blis #temp dependency until rust-bio-tools patch goes through


### PR DESCRIPTION
Make blis dependency explicit (for now); fixes https://github.com/sunbeam-labs/sunbeam/issues/286

* [ ] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
