### PR TITLE
Various testing and dependency fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: install
           command: |
-            bash install.sh -u lib -e sunbeam
+            bash install.sh -u lib -e sunbeam -m
           no_output_timeout: 20m
 
       - run:

--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,7 @@ See how people are using Sunbeam:
 
 #### Development version (future 3.0 release; as of December 2, 2019)
 
+ - Support [mamba](https://github.com/mamba-org/mamba) as an alternate package dependency solver at install time, for faster installs
  - New command `sunbeam extend` to automatically install Sunbeam extensions! Use like `sunbeam extend https://github.com/sunbeam-labs/sbx_report`
  - `sunbeam init` and `sunbeam config update` now add options for extensions you've installed to your default config file! (#247)
  - Updated the path to the Illumina adapter sequences from hardcoded to templated (fixes #150 and #152)

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - bwa>=0.7.17
   - pysam
   - pandas
-  - megahit<1.2
+  - megahit<1.2,>1.1.2
   - prodigal
   - semantic_version
   - setuptools_scm

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -226,17 +226,23 @@ function test_mapping {
     for file in $TEMPDIR/hosts_*; do
         mv $file ${file/hosts_/hosts\//}
     done
-    # After the header line, there should be two lines in the human coverage
-    # summary and none at all in the phix174 summary.  The human.csv lines
-    # should be sorted in standard alphanumeric order; stub2_human will come
-    # before stub_human.
+    # After the header line, there should be two lines in the human and phix
+    # coverage summaries, with two reads mapping for human and none for phix.
+    # The lines should be sorted in standard alphanumeric order; stub2_human
+    # will come before stub_human.
     (
 	    csv_human=$TEMPDIR/sunbeam_output/mapping/human/coverage.csv
 	    csv_phix=$TEMPDIR/sunbeam_output/mapping/phix174/coverage.csv
 	    function col3 { cut -f3 -d, | tr '\n' : ; }
+	    function col5 { cut -f5 -d, | tr '\n' : ; }
 	    test "Sample:stub2_human:stub_human:" == $(col3 < "$csv_human")
-	    test "Sample:" == $(col3 < "$csv_phix")
-    )
+	    test "Max:2:2:" == $(col5 < "$csv_human")
+	    test "Sample:stub2_human:stub_human:" == $(col3 < "$csv_phix")
+	    test "Max:0:0:" == $(col5 < "$csv_phix")
+    ) || (
+	    echo "Unexpected coverage.csv content from mapping rules" > /dev/stderr
+	    false
+	)
 }
 
 # Test for sunbeam init for SRA


### PR DESCRIPTION
* [X] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] ~~If this adds a new output file, I have added a check to tests/targets.txt~~
* [X] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] ~~If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`~~

This addresses a few different things to get our tests passing again:

 * Allow the use of [mamba](https://github.com/mamba-org/mamba) as an alternate dependency solver and use it for CircleCI testing.  This is so that the automated tests can install the environment in a reasonable amount of time (and real installs too, with `./install.sh -m`) and with lower RAM usage.  If mamba is already installed it will be used to set up the environment.
 * Require megahit >1.1.2 as we all <1.2.  Recently the dependency resolution has been installing the earliest available megahit package on bioconda, which incidentally has all of its executables stored at the top level of the environment instead of in `$CONDA_PREFIX/bin`.  This ensures that version won't get installed and in the long run we'll probably raise the minimum anyway when migrating to newer megahit.
 * Fixes the coverage.csv checks in `test_mapping`.  These were silently failing because of explicit zero-read rows in phix's coverage table instead of missing rows, and a lack of an error message made it extra confusing to figure out.  Now the test matches the actual output, and if it fails, shows an error message.

Fixes #269.