### PR TITLE
Add explicit mkl dependency for rust-bio-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v3-dependencies-{{ checksum "environment.yml" }}
+          - v3-dependencies-{{ .Branch }}-{{ checksum "environment.yml" }}
 
       - run:
           name: install
@@ -36,7 +36,7 @@ jobs:
       - save_cache:
           paths:
             - ~/miniconda3
-          key: v3-dependencies-{{ checksum "environment.yml" }}
+          key: v3-dependencies-{{ .Branch }}-{{ checksum "environment.yml" }}
 
 workflows:
   version: 2

--- a/environment.yml
+++ b/environment.yml
@@ -30,3 +30,4 @@ dependencies:
   - bcftools>=1.9
   - git
   - blis #temp dependency until rust-bio-tools patch goes through
+  - mkl #temp dependency for rust-bio-tools


### PR DESCRIPTION
For some reason, rust-bio-tools, now that we got it updated to include blis as a dependency (#289), now depends on mkl as well (or instead? I actually *don't* see libblis used by the rbt binary in the latest builds).  I described my confusion about that in bioconda/bioconda-recipes#27826 but for our purposes adding mkl to our environment file seems to get it working again. Fixes #293.