### PR TITLE
309 actually adding diamond

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ tests/bacteria
 tests/local
 tests/data_files
 configs/respublica_config.yml
-*.yml
-*.yaml
+#*.yml
+#*.yaml
 *.egg-*
 docs/_build
 extensions/*

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   #- louiejtaylor
 dependencies:
   #- snakemake<5.7.0 #snakemake-minimal?
-  - snakemake
+  - snakemake>5.7.0
   #- snakemake-minimal
   - ruamel.yaml
   - biopython

--- a/environment.yml
+++ b/environment.yml
@@ -1,33 +1,35 @@
 channels:
   - conda-forge
   - bioconda
-  - eclarke
-  - louiejtaylor
+  #- eclarke
+  #- louiejtaylor
 dependencies:
-  - snakemake<5.7.0
+  #- snakemake<5.7.0 #snakemake-minimal?
+  - snakemake
+  #- snakemake-minimal
   - ruamel.yaml
   - biopython
-  - trimmomatic=0.39
-  - fastqc
-  - blast
+  #- trimmomatic=0.39 #
+  #- fastqc           # Redundant?
+  #- cutadapt         #
+  #- blast
   - kraken2
-  - kraken-biom
-  - vsearch
-  - cutadapt
-  - bwa>=0.7.17
-  - pysam
-  - pandas
-  - megahit<1.2,>1.1.2
-  - prodigal
+  #- kraken-biom
+  #- vsearch
+  #- bwa>=0.7.17
+  #- pysam
+  #- pandas
+  #- megahit<1.2,>1.1.2
+  #- prodigal
   - semantic_version
-  - setuptools_scm
-  - komplexity=0.3.6
-  - rust-bio-tools
-  - grabseqs=0.6.1
-  - minimap2
-  - multiqc
-  - samtools>=1.9
-  - bcftools>=1.9
+  #- setuptools_scm
+  #- komplexity=0.3.6
+  #- rust-bio-tools
+  #- grabseqs=0.6.1
+  #- minimap2
+  #- multiqc
+  #- samtools>=1.9
+  #- bcftools>=1.9
   - git
-  - blis #temp dependency until rust-bio-tools patch goes through
-  - mkl #temp dependency for rust-bio-tools
+  #- blis #temp dependency until rust-bio-tools patch goes through
+  #- mkl #temp dependency for rust-bio-tools

--- a/envs/annotation.yml
+++ b/envs/annotation.yml
@@ -4,4 +4,5 @@ channels:
 dependencies:
   - biopython
   - blast
+  - diamond
   - prodigal

--- a/envs/annotation.yml
+++ b/envs/annotation.yml
@@ -1,0 +1,7 @@
+name: annotation
+channels:
+  - bioconda
+dependencies:
+  - biopython
+  - blast
+  - prodigal

--- a/envs/assembly.yml
+++ b/envs/assembly.yml
@@ -1,0 +1,10 @@
+name: assembly
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - megahit
+  - minimap2
+  - numpy
+  - samtools
+  - vsearch

--- a/envs/bcftools_samtools.yml
+++ b/envs/bcftools_samtools.yml
@@ -1,0 +1,5 @@
+channels:
+  - bioconda
+dependencies:
+  - bcftools
+  - samtools

--- a/envs/bcftools_samtools.yml
+++ b/envs/bcftools_samtools.yml
@@ -1,5 +1,8 @@
 channels:
   - bioconda
+  #- conda-forge
 dependencies:
+  - conda-forge::libopenblas
+  - conda-forge::gsl
   - bcftools
-  - samtools
+  #- samtools=1.10

--- a/envs/biopython.yml
+++ b/envs/biopython.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - biopython

--- a/envs/biopython_pysam.yml
+++ b/envs/biopython_pysam.yml
@@ -1,0 +1,5 @@
+channels:
+  - bioconda
+dependencies:
+  - biopython
+  - pysam

--- a/envs/blast.yml
+++ b/envs/blast.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - blast

--- a/envs/bwa.yml
+++ b/envs/bwa.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - bwa

--- a/envs/bwa_samtools.yml
+++ b/envs/bwa_samtools.yml
@@ -1,0 +1,5 @@
+channels:
+  - bioconda
+dependencies:
+  - bwa
+  - samtools

--- a/envs/classify.yml
+++ b/envs/classify.yml
@@ -1,0 +1,6 @@
+name: classify
+channels:
+  - bioconda
+dependencies:
+  #- kraken2
+  - kraken-biom

--- a/envs/cutadapt.yml
+++ b/envs/cutadapt.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - cutadapt

--- a/envs/download.yml
+++ b/envs/download.yml
@@ -1,0 +1,5 @@
+name: download
+channels:
+  - louiejtaylor
+dependencies:
+  - grabseqs

--- a/envs/fastqc.yml
+++ b/envs/fastqc.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - fastqc

--- a/envs/grabseqs.yml
+++ b/envs/grabseqs.yml
@@ -1,0 +1,4 @@
+channels:
+  - louiejtaylor
+dependencies:
+  - grabseqs

--- a/envs/komplexity.yml
+++ b/envs/komplexity.yml
@@ -1,0 +1,4 @@
+channels:
+  - eclarke
+dependencies:
+  - komplexity

--- a/envs/kraken-biom.yml
+++ b/envs/kraken-biom.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - kraken-biom

--- a/envs/mapping.yml
+++ b/envs/mapping.yml
@@ -1,0 +1,11 @@
+name: mapping
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - bcftools
+  - bwa
+  - conda-forge::gsl         # bcftools
+  - conda-forge::libopenblas # bcftools
+  - numpy
+  - samtools

--- a/envs/megahit.yml
+++ b/envs/megahit.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - megahit

--- a/envs/minimap2_samtools.yml
+++ b/envs/minimap2_samtools.yml
@@ -1,0 +1,5 @@
+channels:
+  - bioconda
+dependencies:
+  - minimap2
+  - samtools

--- a/envs/multiqc.yml
+++ b/envs/multiqc.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - multiqc

--- a/envs/numpy.yml
+++ b/envs/numpy.yml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - numpy

--- a/envs/numpy.yml
+++ b/envs/numpy.yml
@@ -1,4 +1,6 @@
 channels:
+  - bioconda
   - conda-forge
 dependencies:
   - numpy
+  - samtools

--- a/envs/pandas.yml
+++ b/envs/pandas.yml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - pandas

--- a/envs/prodigal.yml
+++ b/envs/prodigal.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - prodigal

--- a/envs/qc.yml
+++ b/envs/qc.yml
@@ -1,0 +1,16 @@
+name: qc
+channels:
+  - bioconda
+  - eclarke
+  - conda-forge
+dependencies:
+  - biopython
+  - bwa
+  - cutadapt
+  - fastqc
+  - conda-forge::gsl # rust-bio-tools
+  - komplexity
+  - pysam
+  - rust-bio-tools
+  - samtools
+  - trimmomatic

--- a/envs/reports.yml
+++ b/envs/reports.yml
@@ -1,0 +1,7 @@
+name: reports
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - bioconda::multiqc
+  - conda-forge::pandas

--- a/envs/rust-bio-tools.yml
+++ b/envs/rust-bio-tools.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::gsl
+  - rust-bio-tools

--- a/envs/samtools.yml
+++ b/envs/samtools.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - samtools

--- a/envs/trimmomatic.yml
+++ b/envs/trimmomatic.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - trimmomatic

--- a/envs/vsearch.yml
+++ b/envs/vsearch.yml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - vsearch

--- a/install.sh
+++ b/install.sh
@@ -158,11 +158,13 @@ function install_conda () {
 }
 
 function install_environment () {
-    if [[ $(__test_mamba) = true ]]; then
-        cmd=mamba
-    else
+    #if [[ $(__test_mamba) = true ]]; then
+    #    cmd=mamba
+    #else
         cmd=conda
-    fi
+    #fi
+    #debug_capture $cmd env create --name=$__sunbeam_env \
+    #          --quiet --file environment.yml
     debug_capture $cmd env update --name=$__sunbeam_env \
 			  --quiet --file environment.yml
     if [[ $(__test_env) != true ]]; then
@@ -172,8 +174,10 @@ function install_environment () {
 
 function install_env_vars () {
     activate_sunbeam
+    mkdir -p ${CONDA_PREFIX}/etc/conda/activate.d
     echo -ne "#/bin/sh\nexport SUNBEAM_DIR=${__sunbeam_dir}" > \
 	 ${CONDA_PREFIX}/etc/conda/activate.d/env_vars.sh
+    mkdir -p ${CONDA_PREFIX}/etc/conda/deactivate.d
     echo -ne "#/bin/sh\nunset SUNBEAM_DIR" > \
 	 ${CONDA_PREFIX}/etc/conda/deactivate.d/env_vars.sh
 }

--- a/install.sh
+++ b/install.sh
@@ -158,15 +158,15 @@ function install_conda () {
 }
 
 function install_environment () {
-    #if [[ $(__test_mamba) = true ]]; then
-    #    cmd=mamba
-    #else
+    if [[ $(__test_mamba) = true ]]; then
+        cmd=mamba
+    else
         cmd=conda
-    #fi
-    #debug_capture $cmd env create --name=$__sunbeam_env \
-    #          --quiet --file environment.yml
-    debug_capture $cmd env update --name=$__sunbeam_env \
-			  --quiet --file environment.yml
+    fi
+    debug_capture $cmd env create --name=$__sunbeam_env \
+              --quiet --file environment.yml
+    #debug_capture $cmd env update --name=$__sunbeam_env \
+	#		  --quiet --file environment.yml
     if [[ $(__test_env) != true ]]; then
 	installation_error "Environment creation"
     fi

--- a/rules/annotation/annotation.smk
+++ b/rules/annotation/annotation.smk
@@ -13,10 +13,10 @@ rule aggregate_results:
     input:
         contigs=str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa'),
         contig_results=expand(
-            str(ANNOTATION_FP/'blastn'/'{db}'/'contig'/'{{sample}}.xml'),
+            str(ANNOTATION_FP/'blastn'/'{db}'/'contig'/'{{sample}}.btf'),
             db=Blastdbs['nucl']),
         gene_results=expand(
-            str(ANNOTATION_FP/'{blastpx}'/'{db}'/'{orf_finder}'/'{{sample}}.xml'),
+            str(ANNOTATION_FP/'{blastpx}'/'{db}'/'{orf_finder}'/'{{sample}}.btf'),
             blastpx=['blastp','blastx'],
             db=Blastdbs['prot'],
             orf_finder=['prodigal'])

--- a/rules/annotation/annotation.smk
+++ b/rules/annotation/annotation.smk
@@ -23,7 +23,9 @@ rule aggregate_results:
     output:
         str(ANNOTATION_FP/'summary'/'{sample}.tsv')
     params:
-        dbs=list(Blastdbs['nucl'].keys()) + list(Blastdbs['prot'].keys())
+        dbs=list(Blastdbs['nucl'].keys()) + list(Blastdbs['prot'].keys()),
+        nucl = Blastdbs['nucl'],
+        prot = Blastdbs['prot'],
     conda:
         "../../envs/biopython.yml"
     script:

--- a/rules/annotation/annotation.smk
+++ b/rules/annotation/annotation.smk
@@ -4,13 +4,6 @@
 #
 # See Readme.md
 
-import csv
-from collections import Counter
-from pathlib import Path
-
-from Bio import SeqIO
-from sunbeamlib import circular
-
 
 rule all_annotate:
     input:
@@ -31,45 +24,10 @@ rule aggregate_results:
         str(ANNOTATION_FP/'summary'/'{sample}.tsv')
     params:
         dbs=list(Blastdbs['nucl'].keys()) + list(Blastdbs['prot'].keys())
-    run:
-        contigs = {r.id: r.seq for r in SeqIO.parse(input.contigs, 'fasta')}
-        # Separate each set of result files by the database it was blasted against
-        contig_results = {
-            db: blast_contig_summary(f for f in input.contig_results if db in f)
-            for db in Blastdbs['nucl']
-        }
-        # We only care about the number of hits for the protein database
-        gene_hits = {
-            db: blast_hits(f for f in input.gene_results if db in f)
-            for db in Blastdbs['prot']
-        }
-        with open(output[0], 'w') as out:
-            writer = csv.DictWriter(
-                out,
-                fieldnames=['sample', 'contig', 'length', 'circular'] + params.dbs,
-                delimiter='\t')
-            writer.writeheader()
-            for contig, contig_seq in contigs.items():
-                is_circular = circular(
-                    contig_seq,
-                    Cfg['annotation']['circular_kmin'],
-                    Cfg['annotation']['circular_kmax'],
-                    Cfg['annotation']['circular_min_len'])
-                results = {
-                    'sample':wildcards.sample,
-                    'contig':contig,
-                    'length':len(contig_seq),
-                    'circular':is_circular
-                }
-                for db in Blastdbs['nucl']:                
-                    results[db] = contig_results[db].get(contig, "NA")
-                # Report the number of hits of each contig/gene for each prot. db
-                # Genes are reported from prodigal as contig_1,contig_2, etc so
-                # aggregate all hits for all of a contig's genes together using sum
-                for db in Blastdbs['prot']:
-                    results[db] = sum(
-                        gene_hits[db][gene] for gene in gene_hits[db] if contig in gene)
-                writer.writerow(results)
+    conda:
+        "../../envs/biopython.yml"
+    script:
+        "../../scripts/annotation/aggregate_results.py"
 
 rule aggregate_all:
     input:

--- a/rules/annotation/annotation.smk
+++ b/rules/annotation/annotation.smk
@@ -27,7 +27,7 @@ rule aggregate_results:
         nucl = Blastdbs['nucl'],
         prot = Blastdbs['prot'],
     conda:
-        "../../envs/biopython.yml"
+        "../../envs/annotation.yml"
     script:
         "../../scripts/annotation/aggregate_results.py"
 

--- a/rules/annotation/blast.smk
+++ b/rules/annotation/blast.smk
@@ -21,7 +21,7 @@ rule run_blastn:
     threads: 
         Cfg['blast']['threads']
     conda:
-        "../../envs/blast.yml"
+        "../../envs/annotation.yml"
     shell:
         """
         blastn \
@@ -44,7 +44,7 @@ rule run_blastp:
     threads:
         Cfg['blast']['threads']
     conda:
-        "../../envs/blast.yml"
+        "../../envs/annotation.yml"
     shell:
         """
         blastp \
@@ -67,7 +67,7 @@ rule run_blastx:
     threads:
         Cfg['blast']['threads']
     conda:
-        "../../envs/blast.yml"
+        "../../envs/annotation.yml"
     shell:
         """
         blastx \
@@ -89,7 +89,7 @@ rule blast_report:
     output:
         str(ANNOTATION_FP/'{blast_prog}'/'{db}'/'{query}'/'report.tsv')
     conda:
-        "../../envs/biopython.yml"
+        "../../envs/annotation.yml"
     script:
         "../../scripts/annotation/blast_report.py"
 

--- a/rules/annotation/blast.smk
+++ b/rules/annotation/blast.smk
@@ -10,12 +10,51 @@ import csv
 from Bio import SearchIO
 from xml.etree.ElementTree import ParseError
 
+#rule make_blast_db_prot:
+#    """Use makeblastdb to create any necessary db indeces that don't exist."""
+#    input:
+#        prot = lambda wildcards: Blastdbs['prot'][wildcard.db]
+#    output:
+#        expand(str(GENES_DIR/'{{gene}}.fasta.{index}'),index=['psq','pin','phr'])
+#    conda:
+#        "../../envs/annotation.yml"
+#    shell:
+#        """
+#        makeblastdb -in {input} -dbtype prot
+#        """
+    
+#rule make_blast_db_nucl:
+#    """Use makeblastdb to create any necessary db indeces that don't exist."""
+#    input:
+#        prot = lambda wildcards: Blastdbs['nucl'][wildcard.db]
+#    output:
+#        expand(str(GENES_DIR/'{{gene}}.fasta.{index}'),index=['psq','pin','phr'])
+#    conda:
+#        "../../envs/annotation.yml"
+#    shell:
+#        """
+#        makeblastdb -in {input} -dbtype nucl
+#        """
+
+rule build_diamond_db:
+    """Use diamond makedb to create any necessary db indeces that don't exist."""
+    input:
+        [Blastdbs['prot'][db] for db in Blastdbs['prot']]
+    output:
+        [Blastdbs['prot'][db] + '.dmnd' for db in Blastdbs['prot']]
+    conda:
+        "../../envs/annotation.yml"
+    shell:
+        """
+        diamond makedb --in {input} -d {input}
+        """
+
 rule run_blastn:
-    """Run BLASTn against a given database and write the results to XML."""    
+    """Run BLASTn against a given database and write the results to blast tabular format."""    
     input:
         contigs=str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa')
     output:
-        str(ANNOTATION_FP/'blastn'/'{db}'/'{contigs}'/'{sample}.xml')
+        str(ANNOTATION_FP/'blastn'/'{db}'/'{contigs}'/'{sample}.btf')
     params:
         db=lambda wildcard: Blastdbs['nucl'][wildcard.db] 
     threads: 
@@ -27,7 +66,7 @@ rule run_blastn:
         blastn \
         -query {input.contigs} \
         -db {params.db} \
-        -outfmt 5 \
+        -outfmt 7 \
         -num_threads {threads} \
         -evalue 1e-10 \
         -max_target_seqs 5000 \
@@ -35,12 +74,12 @@ rule run_blastn:
         """
 
 rule run_blastp:
-    """Run BLASTp on translated genes against a target db and write to XML."""
+    """Run BLASTp on translated genes against a target db and write to blast tabular format."""
     input:
         genes=str(ANNOTATION_FP/'genes'/'{orf_finder}'/'{sample}_genes_prot.fa'),
         db=lambda wildcard: Blastdbs['prot'][wildcard.db]
     output:
-        str(ANNOTATION_FP/'blastp'/'{db}'/'{orf_finder}'/'{sample}.xml')
+        str(ANNOTATION_FP/'blastp'/'{db}'/'{orf_finder}'/'{sample}.btf')
     threads:
         Cfg['blast']['threads']
     conda:
@@ -50,7 +89,7 @@ rule run_blastp:
         blastp \
         -query {input.genes} \
         -db {input.db} \
-        -outfmt 5 \
+        -outfmt 7 \
         -num_threads {threads} \
         -evalue 1e-10 \
         -max_target_seqs 2475 \
@@ -58,12 +97,12 @@ rule run_blastp:
         """
 
 rule run_blastx:
-    """Run BLASTx on untranslated genes against a target db and write to XML."""
+    """Run BLASTx on untranslated genes against a target db and write to blast tabular format."""
     input:
         genes=str(ANNOTATION_FP/'genes'/'{orf_finder}'/'{sample}_genes_nucl.fa'),
         db=lambda wildcard: Blastdbs['prot'][wildcard.db]
     output:
-        str(ANNOTATION_FP/'blastx'/'{db}'/'{orf_finder}'/'{sample}.xml')
+        str(ANNOTATION_FP/'blastx'/'{db}'/'{orf_finder}'/'{sample}.btf')
     threads:
         Cfg['blast']['threads']
     conda:
@@ -79,12 +118,37 @@ rule run_blastx:
         -max_target_seqs 2475 \
         -out {output} \
         """
+
+rule run_diamond:
+    """Run DIAMOND on untranslated genes against a target db and write to blast tabular format."""
+    input:
+        genes=str(ANNOTATION_FP/'genes'/'{orf_finder}'/'{sample}_genes_nucl.fa'),
+        db=lambda wildcard: Blastdbs['prot'][wildcard.db],
+        indeces=rules.build_diamond_db.output
+    output:
+        str(ANNOTATION_FP/'blastx'/'{db}'/'{orf_finder}'/'{sample}.btfbutnotrn')
+    threads:
+        Cfg['blast']['threads']
+    conda:
+        "../../envs/annotation.yml"
+    shell:
+        """
+        cat {input.genes} && \
+        diamond blastx \
+        -q {input.genes} \
+        --db {input.db} \
+        --outfmt 6 \
+        --threads {threads} \
+        --evalue 1e-10 \
+        --max-target-seqs 2475 \
+        --out {output}
+        """
         
 rule blast_report:
     """Create a summary of results from a BLAST call."""
     input:
         expand(
-            str(ANNOTATION_FP/'{{blast_prog}}'/'{{db}}'/'{{query}}'/'{sample}.xml'),
+            str(ANNOTATION_FP/'{{blast_prog}}'/'{{db}}'/'{{query}}'/'{sample}.btf'),
             sample=Samples.keys())
     output:
         str(ANNOTATION_FP/'{blast_prog}'/'{db}'/'{query}'/'report.tsv')
@@ -95,7 +159,7 @@ rule blast_report:
 
 rule _test_blastpx:
     input:
-        expand(str(ANNOTATION_FP/'{blastpx}'/'card'/'prodigal'/'{sample}.xml'), 
+        expand(str(ANNOTATION_FP/'{blastpx}'/'card'/'prodigal'/'{sample}.btf'), 
                blastpx=['blastx','blastp'], sample=Samples.keys())
     
 rule _test_blastpx_report:
@@ -103,18 +167,18 @@ rule _test_blastpx_report:
         expand(str(ANNOTATION_FP/'{blastpx}'/'card'/'prodigal'/'report.tsv'),
         blastpx=['blastx','blastp'])
 
-rule clean_xml:
-    input:
-        expand(str(ANNOTATION_FP/'summary'/'{sample}.tsv'), sample=Samples.keys())
-    params:
-        blastn_fp = str(ANNOTATION_FP/'blastn'),
-        blastp_fp = str(ANNOTATION_FP/'blastp'),
-        blastx_fp = str(ANNOTATION_FP/'blastx')
-    output:
-        touch(".xml_cleaned")
-    shell:
-        """
-        if [ -d {params.blastn_fp} ]; then rm -r {params.blastn_fp}; fi && \
-        if [ -d {params.blastp_fp} ]; then rm -r {params.blastp_fp}; fi && \
-        if [ -d {params.blastx_fp} ]; then rm -r {params.blastx_fp}; fi
-        """
+#rule clean_xml:
+#    input:
+#        expand(str(ANNOTATION_FP/'summary'/'{sample}.tsv'), sample=Samples.keys())
+#    params:
+#        blastn_fp = str(ANNOTATION_FP/'blastn'),
+#        blastp_fp = str(ANNOTATION_FP/'blastp'),
+#        blastx_fp = str(ANNOTATION_FP/'blastx')
+#    output:
+#        touch(".xml_cleaned")
+#    shell:
+#        """
+#        if [ -d {params.blastn_fp} ]; then rm -r {params.blastn_fp}; fi && \
+#        if [ -d {params.blastp_fp} ]; then rm -r {params.blastp_fp}; fi && \
+#        if [ -d {params.blastx_fp} ]; then rm -r {params.blastx_fp}; fi
+#        """

--- a/rules/annotation/blast.smk
+++ b/rules/annotation/blast.smk
@@ -20,6 +20,8 @@ rule run_blastn:
         db=lambda wildcard: Blastdbs['nucl'][wildcard.db] 
     threads: 
         Cfg['blast']['threads']
+    conda:
+        "../../envs/blast.yml"
     shell:
         """
         blastn \
@@ -41,6 +43,8 @@ rule run_blastp:
         str(ANNOTATION_FP/'blastp'/'{db}'/'{orf_finder}'/'{sample}.xml')
     threads:
         Cfg['blast']['threads']
+    conda:
+        "../../envs/blast.yml"
     shell:
         """
         blastp \
@@ -62,6 +66,8 @@ rule run_blastx:
         str(ANNOTATION_FP/'blastx'/'{db}'/'{orf_finder}'/'{sample}.xml')
     threads:
         Cfg['blast']['threads']
+    conda:
+        "../../envs/blast.yml"
     shell:
         """
         blastx \
@@ -82,14 +88,10 @@ rule blast_report:
             sample=Samples.keys())
     output:
         str(ANNOTATION_FP/'{blast_prog}'/'{db}'/'{query}'/'report.tsv')
-    run:
-        with open(output[0], 'w') as out:
-            writer = csv.DictWriter(
-	        out,
-	        fieldnames=['sample','query','hit'],
-                delimiter='\t')
-            writer.writeheader()
-            list(writer.writerow(result) for result in blast_summary(input))
+    conda:
+        "../../envs/biopython.yml"
+    script:
+        "../../scripts/annotation/blast_report.py"
 
 rule _test_blastpx:
     input:

--- a/rules/annotation/orf.smk
+++ b/rules/annotation/orf.smk
@@ -16,7 +16,7 @@ rule prodigal:
         fna = str(ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes_nucl.fa'),
         log = str(ANNOTATION_FP/'genes'/'prodigal'/'log'/'{sample}.out')
     conda:
-        "../../envs/prodigal.yml"
+        "../../envs/annotation.yml"
     shell:
         """
         if [[ -s {input} ]]; then

--- a/rules/annotation/orf.smk
+++ b/rules/annotation/orf.smk
@@ -15,6 +15,8 @@ rule prodigal:
         faa = str(ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes_prot.fa'),
         fna = str(ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes_nucl.fa'),
         log = str(ANNOTATION_FP/'genes'/'prodigal'/'log'/'{sample}.out')
+    conda:
+        "../../envs/prodigal.yml"
     shell:
         """
         if [[ -s {input} ]]; then

--- a/rules/assembly/assembly.smk
+++ b/rules/assembly/assembly.smk
@@ -21,6 +21,8 @@ rule megahit_paired:
         out_fp = str(ASSEMBLY_FP/'megahit'/'{sample}_asm')
     threads:
         Cfg['assembly']['threads']
+    conda:
+        "../../envs/megahit.yml"
     shell:
         """
         ## turn off bash strict mode
@@ -49,6 +51,8 @@ rule megahit_unpaired:
         out_fp = str(ASSEMBLY_FP/'megahit'/'{sample}_asm')
     threads:
         Cfg['assembly']['threads']
+    conda:
+        "../../envs/megahit.yml"
     shell:
         """
         ## turn off bash strict mode
@@ -77,22 +81,10 @@ rule final_filter:
         len = Cfg['assembly']['min_length']
     log:
         str(ASSEMBLY_FP/'log'/'vsearch'/'{sample}.log')
-    run:
-        filename = os.path.basename(input[0])
-        shell(
-        """
-        if [ -s {input} ]
-        then
-            vsearch --sortbylength {input} \
-            --minseqlength {params.len} \
-            --maxseqlength -1 \
-            --notrunclabels \
-            --output {input}.{params.len}f &> {log} && \
-            cp {input}.{params.len}f {output}
-        else
-            cp {input} {output} &> {log}
-        fi
-        """)
+    conda:
+        "../../envs/vsearch.yml"
+    script:
+        "../../scripts/assembly/final_filter.py"
 
 rule clean_assembly:
     input:

--- a/rules/assembly/assembly.smk
+++ b/rules/assembly/assembly.smk
@@ -30,8 +30,14 @@ rule megahit_paired:
 
         ## sometimes the error is due to lack of memory
         exitcode=0
+        ls -al {params.out_fp} > /mnt/d/Penn/sunbeam/log.txt
+        if [ -d {params.out_fp} ]
+        then
+            rm -rf {params.out_fp}
+        fi
         megahit -t {threads} -1 {input.r1} -2 {input.r2} -o {params.out_fp} --continue || exitcode=$?
 
+        echo $exitcode
         if [ $exitcode -eq 255 ]
         then
             echo "Empty contigs"

--- a/rules/assembly/assembly.smk
+++ b/rules/assembly/assembly.smk
@@ -22,7 +22,7 @@ rule megahit_paired:
     threads:
         Cfg['assembly']['threads']
     conda:
-        "../../envs/megahit.yml"
+        "../../envs/assembly.yml"
     shell:
         """
         ## turn off bash strict mode
@@ -58,7 +58,7 @@ rule megahit_unpaired:
     threads:
         Cfg['assembly']['threads']
     conda:
-        "../../envs/megahit.yml"
+        "../../envs/assembly.yml"
     shell:
         """
         ## turn off bash strict mode
@@ -88,7 +88,7 @@ rule final_filter:
     log:
         str(ASSEMBLY_FP/'log'/'vsearch'/'{sample}.log')
     conda:
-        "../../envs/vsearch.yml"
+        "../../envs/assembly.yml"
     script:
         "../../scripts/assembly/final_filter.py"
 

--- a/rules/assembly/coverage.smk
+++ b/rules/assembly/coverage.smk
@@ -30,7 +30,7 @@ rule contigs_mapping:
     threads: 
         Cfg['mapping']['threads']
     conda:
-        "../../envs/minimap2_samtools.yml"
+        "../../envs/assembly.yml"
     shell:
         """
         minimap2 -ax sr -t {threads} {input.contig} {input.reads} | \
@@ -45,7 +45,7 @@ rule mapping_depth:
     output:
         depth = str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth')
     conda:
-        "../../envs/samtools.yml"
+        "../../envs/assembly.yml"
     shell:
         """
         samtools depth -aa {input.bam} > {output.depth}
@@ -58,7 +58,7 @@ rule get_coverage:
     output:
         str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv')
     conda:
-        "../../envs/numpy.yml"
+        "../../envs/assembly.yml"
     script:
         "../../scripts/assembly/get_coverage.py"
 

--- a/rules/assembly/coverage.smk
+++ b/rules/assembly/coverage.smk
@@ -4,11 +4,6 @@
 #
 # Requires Minimap2 and samtools.
 
-
-import csv
-import numpy
-
-
 rule all_coverage:
     input:
         str(ASSEMBLY_FP/'contigs_coverage.txt')
@@ -34,6 +29,8 @@ rule contigs_mapping:
         temp = temp(str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.tmp'))
     threads: 
         Cfg['mapping']['threads']
+    conda:
+        "../../envs/minimap2_samtools.yml"
     shell:
         """
         minimap2 -ax sr -t {threads} {input.contig} {input.reads} | \
@@ -47,44 +44,12 @@ rule mapping_depth:
         bai = str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam.bai')
     output:
         depth = str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth')
+    conda:
+        "../../envs/samtools.yml"
     shell:
         """
         samtools depth -aa {input.bam} > {output.depth}
         """
-
-def _get_coverage(input_fp, sample, output_fp):
-    """
-    Summarize stats for coverage data for each sample 
-    """
-
-    with open(input_fp) as f:
-        reader = csv.reader(f, delimiter='\t')    
-        data = {}
-        for row in reader:
-            if not data.get(row[0]):
-                data[row[0]] = []
-            data[row[0]].append(int(row[2]))
-    
-    # summarize stats for all segments present and append to output
-    output_rows = []
-    for segment in data.keys():
-        sumval     = numpy.sum(data[segment])
-        minval     = numpy.min(data[segment])
-        maxval     = numpy.max(data[segment])
-        mean       = numpy.mean(data[segment])
-        median     = numpy.median(data[segment])
-        stddev     = numpy.std(data[segment])
-        gen_cov    = len(list(filter(lambda x: x!=0, data[segment])))
-        gen_length = len(data[segment])
-        row = [sample, segment, sumval, minval, maxval, mean, median, stddev, gen_cov, gen_length]
-        output_rows.append(row)
-
-    # write out stats per segment per sample
-    fields = ['sample','contig', 'sum', 'min', 'max', 'mean', 'median', 'stddev', 'coverage', 'length']
-    with open(output_fp, 'w') as f:
-        writer = csv.writer(f)
-        writer.writerow(fields)
-        writer.writerows(output_rows)
 
 
 rule get_coverage:
@@ -92,8 +57,10 @@ rule get_coverage:
         str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth')
     output:
         str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv')
-    run:
-        _get_coverage(input[0], wildcards.sample, output[0])
+    conda:
+        "../../envs/numpy.yml"
+    script:
+        "../../scripts/assembly/get_coverage.py"
 
 
 rule summarize_coverage:

--- a/rules/classify/kraken.smk
+++ b/rules/classify/kraken.smk
@@ -18,7 +18,7 @@ rule kraken2_classify_report:
     threads:
         Cfg['classify']['threads']
     #conda:
-    #    "../../envs/kraken2.yml"
+    #    "../../envs/classify.yml"
     shell:
         """
         kraken2 --gzip-compressed \
@@ -35,7 +35,7 @@ rule kraken2_biom:
     output:
         str(CLASSIFY_FP/'kraken'/'all_samples.biom')
     conda:
-        "../../envs/kraken-biom.yml"
+        "../../envs/classify.yml"
     shell:
         """
         kraken-biom --max D -o {output} {input}
@@ -47,7 +47,7 @@ rule classic_k2_biom:
     output:
         str(CLASSIFY_FP/'kraken'/'all_samples.tsv')
     conda:
-        "../../envs/kraken-biom.yml"
+        "../../envs/classify.yml"
     shell:
         """
         biom convert -i {input} -o {output} \

--- a/rules/classify/kraken.smk
+++ b/rules/classify/kraken.smk
@@ -17,6 +17,8 @@ rule kraken2_classify_report:
         paired_end = "--paired" if Cfg['all']['paired_end'] else ""
     threads:
         Cfg['classify']['threads']
+    #conda:
+    #    "../../envs/kraken2.yml"
     shell:
         """
         kraken2 --gzip-compressed \
@@ -32,6 +34,8 @@ rule kraken2_biom:
                sample=Samples.keys())
     output:
         str(CLASSIFY_FP/'kraken'/'all_samples.biom')
+    conda:
+        "../../envs/kraken-biom.yml"
     shell:
         """
         kraken-biom --max D -o {output} {input}
@@ -42,6 +46,8 @@ rule classic_k2_biom:
         str(CLASSIFY_FP/'kraken'/'all_samples.biom')
     output:
         str(CLASSIFY_FP/'kraken'/'all_samples.tsv')
+    conda:
+        "../../envs/kraken-biom.yml"
     shell:
         """
         biom convert -i {input} -o {output} \

--- a/rules/download/download.smk
+++ b/rules/download/download.smk
@@ -14,6 +14,8 @@ rule download_paired:
     threads:
         Cfg['download']['threads']
     shadow: "shallow"
+    conda:
+        "../../envs/grabseqs.yml"
     shell:
         """
         mkdir -p {params.outdir}
@@ -29,6 +31,8 @@ rule download_unpaired:
     threads:
         Cfg['download']['threads']	
     shadow: "shallow"
+    conda:
+        "../../envs/grabseqs.yml"
     shell:
         """
         mkdir -p {params.outdir}

--- a/rules/download/download.smk
+++ b/rules/download/download.smk
@@ -15,7 +15,7 @@ rule download_paired:
         Cfg['download']['threads']
     shadow: "shallow"
     conda:
-        "../../envs/grabseqs.yml"
+        "../../envs/download.yml"
     shell:
         """
         mkdir -p {params.outdir}
@@ -32,7 +32,7 @@ rule download_unpaired:
         Cfg['download']['threads']	
     shadow: "shallow"
     conda:
-        "../../envs/grabseqs.yml"
+        "../../envs/download.yml"
     shell:
         """
         mkdir -p {params.outdir}

--- a/rules/mapping/mapping.smk
+++ b/rules/mapping/mapping.smk
@@ -9,7 +9,7 @@ rule build_genome_index:
     output:
         str(Cfg['mapping']['genomes_fp']/'{genome}.fasta.amb')
     conda:
-        "../../envs/bwa.yml"
+        "../../envs/mapping.yml"
     shell:
         "cd {Cfg[mapping][genomes_fp]} && bwa index {input}"
 
@@ -26,7 +26,7 @@ rule align_to_genome:
     params:
         index_fp = str(Cfg['mapping']['genomes_fp'])
     conda:
-        "../../envs/bwa.yml"
+        "../../envs/mapping.yml"
     shell:
         """
         bwa mem -M -t {threads} \
@@ -42,7 +42,7 @@ rule samtools_convert:
     threads:
         Cfg['mapping']['threads']
     conda:
-        "../../envs/samtools.yml"
+        "../../envs/mapping.yml"
     shell:
         """
         samtools view -@ {threads} -b {Cfg[mapping][samtools_opts]} {input} | \
@@ -66,7 +66,7 @@ rule samtools_get_coverage:
     output:
         str(MAPPING_FP/'intermediates'/'{genome}'/'{sample}.csv')
     conda:
-        "../../envs/numpy.yml"
+        "../../envs/mapping.yml"
     script:
         "../../scripts/mapping/samtools_get_coverage.py"
 
@@ -74,7 +74,7 @@ rule samtools_index:
     input: str(MAPPING_FP/'{genome}'/'{sample}.bam')
     output: str(MAPPING_FP/'{genome}'/'{sample}.bam.bai')
     conda:
-        "../../envs/samtools.yml"
+        "../../envs/mapping.yml"
     shell:
         "samtools index {input} {output}"
 
@@ -85,7 +85,7 @@ rule samtools_mpileup:
         genome = str(Cfg['mapping']['genomes_fp']/'{genome}.fasta')
     output: str(MAPPING_FP/'{genome}'/'{sample}.raw.bcf')
     conda:
-        "../../envs/bcftools_samtools.yml"
+        "../../envs/mapping.yml"
     shell:
         """
         bcftools mpileup -f {input.genome} {input.bam} | \

--- a/rules/mapping/mapping.smk
+++ b/rules/mapping/mapping.smk
@@ -88,6 +88,6 @@ rule samtools_mpileup:
         "../../envs/bcftools_samtools.yml"
     shell:
         """
-        samtools mpileup -gf {input.genome} {input.bam} | \
+        bcftools mpileup -f {input.genome} {input.bam} | \
         bcftools call -Ob -v -c - > {output}
         """

--- a/rules/qc/decontaminate.smk
+++ b/rules/qc/decontaminate.smk
@@ -15,7 +15,7 @@ rule build_host_index:
         host='{host}',
         index_fp=str(Cfg['qc']['host_fp'])
     conda:
-        "../../envs/bwa.yml"
+        "../../envs/qc.yml"
     shell:
         "cd {Cfg[qc][host_fp]} && bwa index {input}"
 
@@ -33,7 +33,7 @@ rule align_to_host:
         sam = temp(str(QC_FP/'decontam'/'intermediates'/'{host}'/'{sample}.sam')),
         index_fp = str(Cfg['qc']['host_fp'])
     conda:
-        "../../envs/bwa_samtools.yml"
+        "../../envs/qc.yml"
     shell:
         """
         bwa mem -M -t {threads} \
@@ -52,7 +52,7 @@ rule get_mapped_reads:
         pct_id =  Cfg['qc']['pct_id'],
         frac = Cfg['qc']['frac']
     conda:
-        "../../envs/biopython_pysam.yml"
+        "../../envs/qc.yml"
     script:
         "../../scripts/qc/get_mapped_reads.py"
 
@@ -75,6 +75,6 @@ rule filter_reads:
         reads = str(QC_FP/'decontam'/'{sample}_{rp}.fastq.gz'),
         log = str(QC_FP/'log'/'decontam'/'{sample}_{rp}.txt')
     conda:
-        "../../envs/rust-bio-tools.yml"
+        "../../envs/qc.yml"
     script:
         "../../scripts/qc/filter_reads.py"

--- a/rules/qc/qc.smk
+++ b/rules/qc/qc.smk
@@ -19,7 +19,7 @@ rule sample_intake:
     params:
         suffix = Cfg['qc']['seq_id_ending']
     conda:
-        "../../envs/bwa.yml"
+        "../../envs/qc.yml"
     script:
         "../../scripts/qc/sample_intake.py"
 
@@ -34,7 +34,7 @@ rule adapter_removal_unpaired:
     threads:
         Cfg['qc']['threads']
     conda:
-        "../../envs/cutadapt.yml"
+        "../../envs/qc.yml"
     script:
         "../../scripts/qc/adapter_removal_unpaired.py"
     
@@ -52,7 +52,7 @@ rule adapter_removal_paired:
     threads:
         Cfg['qc']['threads']
     conda:
-        "../../envs/cutadapt.yml"
+        "../../envs/qc.yml"
     script:
         "../../scripts/qc/adapter_removal_paired.py"
 
@@ -70,7 +70,7 @@ rule trimmomatic_unpaired:
     threads:
         Cfg['qc']['threads']
     conda:
-        "../../envs/trimmomatic.yml"
+        "../../envs/qc.yml"
     shell:
         """
         trimmomatic \
@@ -101,7 +101,7 @@ rule trimmomatic_paired:
     threads:
         Cfg['qc']['threads']
     conda:
-        "../../envs/trimmomatic.yml"
+        "../../envs/qc.yml"
     shell:
         """
         trimmomatic \
@@ -129,7 +129,7 @@ rule fastqc:
     params:
         outdir = str(QC_FP/'reports')
     conda:
-        "../../envs/fastqc.yml"
+        "../../envs/qc.yml"
     shell:
         "fastqc -o {params.outdir} {input.reads} -extract"
 
@@ -141,7 +141,7 @@ rule find_low_complexity:
     output:
         str(QC_FP/'log'/'komplexity'/'{sample}.filtered_ids')
     conda:
-        "../../envs/komplexity.yml"
+        "../../envs/qc.yml"
     shell:
         """
         for rp in {input}; do
@@ -157,7 +157,7 @@ rule remove_low_complexity:
     output:
         str(QC_FP/'03_komplexity'/'{sample}_{rp}.fastq.gz')
     conda:
-        "../../envs/rust-bio-tools.yml"
+        "../../envs/qc.yml"
     shell:
         """
         gzip -dc {input.reads} | rbt fastq-filter {input.ids} |\

--- a/rules/qc/qc.smk
+++ b/rules/qc/qc.smk
@@ -18,11 +18,10 @@ rule sample_intake:
         str(QC_FP/'00_samples'/'{sample}_{rp}.fastq.gz')
     params:
         suffix = Cfg['qc']['seq_id_ending']
-    run:
-        if params.suffix:
-            qc.strip_seq_id_suffix(input[0], output[0], params.suffix)
-        else:
-            Path(output[0]).symlink_to(input[0])
+    conda:
+        "../../envs/bwa.yml"
+    script:
+        "../../scripts/qc/sample_intake.py"
 
 rule adapter_removal_unpaired:
     input:
@@ -34,30 +33,10 @@ rule adapter_removal_unpaired:
         str(QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz')
     threads:
         Cfg['qc']['threads']
-    run:
-        fwd_adapters = Cfg['qc'].get('fwd_adapters')
-        rev_adapters = Cfg['qc'].get('rev_adapters')
-        if fwd_adapters or rev_adapters:
-            overlap = float('inf')
-            if fwd_adapters:
-                overlap = min(min(len(a) for a in fwd_adapters), overlap)
-                fwd_adapter_str = " ".join(expand(
-                    "-b {adapter}", adapter=Cfg['qc']['fwd_adapters']))
-            if rev_adapters:
-                overlap = min(min(len(a) for a in rev_adapters), overlap)
-                rev_adapter_str = " ".join(expand(
-                    "-g {adapter}", adapter=Cfg['qc']['rev_adapters']))
-            shell("""
-            cutadapt --discard-trimmed -O {overlap} \
-            --cores {threads} \
-            {fwd_adapter_str} {rev_adapter_str} \
-            -o {params.tmp} \
-            {input} \
-            > >(tee -a {log}) 2> >(tee -a {log} >&2) 
-            gzip {params.tmp}
-            """)
-        else:
-            shell("ln -s {input} {output}")
+    conda:
+        "../../envs/cutadapt.yml"
+    script:
+        "../../scripts/qc/adapter_removal_unpaired.py"
     
 rule adapter_removal_paired:
     input:
@@ -72,33 +51,10 @@ rule adapter_removal_paired:
         gr2 = str(QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz')
     threads:
         Cfg['qc']['threads']
-    run:
-        fwd_adapters = Cfg['qc']['fwd_adapters']
-        rev_adapters = Cfg['qc']['rev_adapters']
-        if fwd_adapters or rev_adapters:
-            overlap = float('inf')
-            if fwd_adapters:
-                overlap = min(min(len(a) for a in fwd_adapters), overlap)
-                fwd_adapter_str = " ".join(expand(
-                    "-b {adapter}", adapter=Cfg['qc']['fwd_adapters']))
-            if rev_adapters:
-                overlap = min(min(len(a) for a in rev_adapters), overlap)
-                rev_adapter_str = " ".join(expand(
-                    "-B {adapter}", adapter=Cfg['qc']['rev_adapters']))
-            shell("""
-            cutadapt --discard-trimmed -O {overlap} \
-            --cores {threads} \
-            {fwd_adapter_str} {rev_adapter_str} \
-            -o {params.r1} -p {params.r2} \
-            {input.r1} {input.r2} \
-            > >(tee -a {log}) 2> >(tee -a {log} >&2) 
-            gzip {params.r1}
-            gzip {params.r2}
-            """)
-        else:
-            shell("""
-            ln -s {input.r1} {output.gr1} && ln -s {input.r2} {output.gr2}
-            """)
+    conda:
+        "../../envs/cutadapt.yml"
+    script:
+        "../../scripts/qc/adapter_removal_paired.py"
 
 ruleorder: trimmomatic_paired > trimmomatic_unpaired
         
@@ -113,6 +69,8 @@ rule trimmomatic_unpaired:
         sw_end = Cfg['qc']['slidingwindow'][1]
     threads:
         Cfg['qc']['threads']
+    conda:
+        "../../envs/trimmomatic.yml"
     shell:
         """
         trimmomatic \
@@ -142,6 +100,8 @@ rule trimmomatic_paired:
         sw_end = Cfg['qc']['slidingwindow'][1]
     threads:
         Cfg['qc']['threads']
+    conda:
+        "../../envs/trimmomatic.yml"
     shell:
         """
         trimmomatic \
@@ -168,6 +128,8 @@ rule fastqc:
             rp=Pairs)
     params:
         outdir = str(QC_FP/'reports')
+    conda:
+        "../../envs/fastqc.yml"
     shell:
         "fastqc -o {params.outdir} {input.reads} -extract"
 
@@ -178,6 +140,8 @@ rule find_low_complexity:
             rp=Pairs)
     output:
         str(QC_FP/'log'/'komplexity'/'{sample}.filtered_ids')
+    conda:
+        "../../envs/komplexity.yml"
     shell:
         """
         for rp in {input}; do
@@ -192,6 +156,8 @@ rule remove_low_complexity:
         ids = str(QC_FP/'log'/'komplexity'/'{sample}.filtered_ids')
     output:
         str(QC_FP/'03_komplexity'/'{sample}_{rp}.fastq.gz')
+    conda:
+        "../../envs/rust-bio-tools.yml"
     shell:
         """
         gzip -dc {input.reads} | rbt fastq-filter {input.ids} |\

--- a/rules/reports/reports.smk
+++ b/rules/reports/reports.smk
@@ -19,7 +19,7 @@ rule preprocess_report:
     output:
         str(QC_FP/'reports'/'preprocess_summary.tsv')
     conda:
-        "../../envs/pandas.yml"
+        "../../envs/reports.yml"
     script:
         "../../scripts/reports/preprocess_report.py"
 
@@ -33,7 +33,7 @@ rule fastqc_report:
     output:
         str(QC_FP/'reports'/'fastqc_quality.tsv')
     conda:
-        "../../envs/pandas.yml"
+        "../../envs/reports.yml"
     script:
         "../../scripts/reports/fastqc_report.py"
 
@@ -48,6 +48,6 @@ rule multiqc_report:
         title = Cfg['qc'].get('report_title', 'QC report'),
         outdir = str(QC_FP/'reports')
     conda:
-        "../../envs/multiqc.yml"
+        "../../envs/reports.yml"
     script:
         "../../scripts/reports/multiqc_report.py"

--- a/scripts/annotation/aggregate_results.py
+++ b/scripts/annotation/aggregate_results.py
@@ -1,17 +1,18 @@
 import csv
 from Bio import SeqIO
 from sunbeamlib import circular
+from sunbeamlib.reports import blast_contig_summary, blast_hits
 
 contigs = {r.id: r.seq for r in SeqIO.parse(snakemake.input.contigs, 'fasta')}
 # Separate each set of result files by the database it was blasted against
 contig_results = {
     db: blast_contig_summary(f for f in snakemake.input.contig_results if db in f)
-    for db in snakemake.Blastdbs['nucl']
+    for db in snakemake.params.nucl
 }
 # We only care about the number of hits for the protein database
 gene_hits = {
     db: blast_hits(f for f in snakemake.input.gene_results if db in f)
-    for db in snakemake.Blastdbs['prot']
+    for db in snakemake.params.prot
 }
 with open(snakemake.output[0], 'w') as out:
     writer = csv.DictWriter(
@@ -31,12 +32,12 @@ with open(snakemake.output[0], 'w') as out:
             'length':len(contig_seq),
             'circular':is_circular
         }
-        for db in snakemake.Blastdbs['nucl']:                
+        for db in snakemake.params.nucl:                
             results[db] = contig_results[db].get(contig, "NA")
         # Report the number of hits of each contig/gene for each prot. db
         # Genes are reported from prodigal as contig_1,contig_2, etc so
         # aggregate all hits for all of a contig's genes together using sum
-        for db in snakemake.Blastdbs['prot']:
+        for db in snakemake.params.prot:
             results[db] = sum(
                 gene_hits[db][gene] for gene in gene_hits[db] if contig in gene)
         writer.writerow(results)

--- a/scripts/annotation/aggregate_results.py
+++ b/scripts/annotation/aggregate_results.py
@@ -1,0 +1,42 @@
+import csv
+from Bio import SeqIO
+from sunbeamlib import circular
+
+contigs = {r.id: r.seq for r in SeqIO.parse(snakemake.input.contigs, 'fasta')}
+# Separate each set of result files by the database it was blasted against
+contig_results = {
+    db: blast_contig_summary(f for f in snakemake.input.contig_results if db in f)
+    for db in snakemake.Blastdbs['nucl']
+}
+# We only care about the number of hits for the protein database
+gene_hits = {
+    db: blast_hits(f for f in snakemake.input.gene_results if db in f)
+    for db in snakemake.Blastdbs['prot']
+}
+with open(snakemake.output[0], 'w') as out:
+    writer = csv.DictWriter(
+        out,
+        fieldnames=['sample', 'contig', 'length', 'circular'] + snakemake.params.dbs,
+        delimiter='\t')
+    writer.writeheader()
+    for contig, contig_seq in contigs.items():
+        is_circular = circular(
+            contig_seq,
+            snakemake.config['annotation']['circular_kmin'],
+            snakemake.config['annotation']['circular_kmax'],
+            snakemake.config['annotation']['circular_min_len'])
+        results = {
+            'sample':snakemake.wildcards.sample,
+            'contig':contig,
+            'length':len(contig_seq),
+            'circular':is_circular
+        }
+        for db in snakemake.Blastdbs['nucl']:                
+            results[db] = contig_results[db].get(contig, "NA")
+        # Report the number of hits of each contig/gene for each prot. db
+        # Genes are reported from prodigal as contig_1,contig_2, etc so
+        # aggregate all hits for all of a contig's genes together using sum
+        for db in snakemake.Blastdbs['prot']:
+            results[db] = sum(
+                gene_hits[db][gene] for gene in gene_hits[db] if contig in gene)
+        writer.writerow(results)

--- a/scripts/annotation/blast_report.py
+++ b/scripts/annotation/blast_report.py
@@ -1,0 +1,11 @@
+import csv
+from Bio import SearchIO
+from xml.etree.ElementTree import ParseError
+
+with open(snakemake.output[0], 'w') as out:
+    writer = csv.DictWriter(
+    out,
+    fieldnames=['sample','query','hit'],
+        delimiter='\t')
+    writer.writeheader()
+    list(writer.writerow(result) for result in blast_summary(snakemake.input))

--- a/scripts/assembly/final_filter.py
+++ b/scripts/assembly/final_filter.py
@@ -9,7 +9,7 @@ then
     --minseqlength {b} \
     --maxseqlength -1 \
     --notrunclabels \
-    --output {a}.{b}f &> {c} && \
+    --output {a}.{b}f && \
     cp {a}.{b}f {d}
 else
     cp {a} {d} &> {c}

--- a/scripts/assembly/final_filter.py
+++ b/scripts/assembly/final_filter.py
@@ -1,0 +1,17 @@
+import os
+
+filename = os.path.basename(snakemake.input[0])
+os.system(
+"""
+if [ -s {a} ]
+then
+    vsearch --sortbylength {a} \
+    --minseqlength {b} \
+    --maxseqlength -1 \
+    --notrunclabels \
+    --output {a}.{b}f &> {c} && \
+    cp {a}.{b}f {d}
+else
+    cp {a} {d} &> {c}
+fi
+""".format(a=snakemake.input, b=snakemake.params.len, c=snakemake.log, d=snakemake.output))

--- a/scripts/assembly/get_coverage.py
+++ b/scripts/assembly/get_coverage.py
@@ -6,7 +6,7 @@ import csv
 import numpy
 
 input_fp = snakemake.input[0]
-sample = snakemake.wilcards.sample
+sample = snakemake.wildcards.sample
 output_fp = snakemake.output[0]
 
 with open(input_fp) as f:

--- a/scripts/assembly/get_coverage.py
+++ b/scripts/assembly/get_coverage.py
@@ -1,0 +1,39 @@
+"""
+Summarize stats for coverage data for each sample 
+"""
+
+import csv
+import numpy
+
+input_fp = snakemake.input[0]
+sample = snakemake.wilcards.sample
+output_fp = snakemake.output[0]
+
+with open(input_fp) as f:
+    reader = csv.reader(f, delimiter='\t')    
+    data = {}
+    for row in reader:
+        if not data.get(row[0]):
+            data[row[0]] = []
+        data[row[0]].append(int(row[2]))
+
+# summarize stats for all segments present and append to output
+output_rows = []
+for segment in data.keys():
+    sumval     = numpy.sum(data[segment])
+    minval     = numpy.min(data[segment])
+    maxval     = numpy.max(data[segment])
+    mean       = numpy.mean(data[segment])
+    median     = numpy.median(data[segment])
+    stddev     = numpy.std(data[segment])
+    gen_cov    = len(list(filter(lambda x: x!=0, data[segment])))
+    gen_length = len(data[segment])
+    row = [sample, segment, sumval, minval, maxval, mean, median, stddev, gen_cov, gen_length]
+    output_rows.append(row)
+
+# write out stats per segment per sample
+fields = ['sample','contig', 'sum', 'min', 'max', 'mean', 'median', 'stddev', 'coverage', 'length']
+with open(output_fp, 'w') as f:
+    writer = csv.writer(f)
+    writer.writerow(fields)
+    writer.writerows(output_rows)

--- a/scripts/mapping/samtools_get_coverage.py
+++ b/scripts/mapping/samtools_get_coverage.py
@@ -1,0 +1,4 @@
+from sunbeamlib import samtools
+
+samtools.get_coverage_stats(
+    snakemake.wildcards.genome, snakemake.input[0], snakemake.wildcards.sample, snakemake.output[0])

--- a/scripts/qc/adapter_removal_paired.py
+++ b/scripts/qc/adapter_removal_paired.py
@@ -1,0 +1,27 @@
+import os
+
+fwd_adapters = snakemake.config['qc']['fwd_adapters']
+rev_adapters = snakemake.config['qc']['rev_adapters']
+if fwd_adapters or rev_adapters:
+    overlap = float('inf')
+    if fwd_adapters:
+        overlap = min(min(len(a) for a in fwd_adapters), overlap)
+        fwd_adapter_str = "-b " + " -b ".join(snakemake.config['qc']['fwd_adapters'])
+    if rev_adapters:
+        overlap = min(min(len(a) for a in rev_adapters), overlap)
+        rev_adapter_str = "-B " + " -B ".join(snakemake.config['qc']['rev_adapters'])
+    os.system("""
+    cutadapt --discard-trimmed -O {a} \
+    --cores {b} \
+    {c} {d} \
+    -o {e} -p {f} \
+    {g} {h} \
+    > {j} 2>&1
+    gzip {e}
+    gzip {f}
+    """.format(a=overlap, b=snakemake.threads, c=fwd_adapter_str, d=rev_adapter_str, e=snakemake.params.r1, f=snakemake.params.r2,
+            g=snakemake.input.r1, h=snakemake.input.r2, j=snakemake.log))
+else:
+    os.system("""
+    ln -s {a} {b} && ln -s {c} {d}
+    """.format(a=snakemake.input.r1, b=snakemake.output.gr1, c=snakemake.input.r2, d=snakemake.output.gr2))

--- a/scripts/qc/adapter_removal_unpaired.py
+++ b/scripts/qc/adapter_removal_unpaired.py
@@ -1,0 +1,26 @@
+import os
+
+fwd_adapters = snakemake.config['qc']['fwd_adapters']
+rev_adapters = snakemake.config['qc']['rev_adapters']
+if fwd_adapters or rev_adapters:
+    overlap = float('inf')
+    if fwd_adapters:
+        overlap = min(min(len(a) for a in fwd_adapters), overlap)
+        fwd_adapter_str = "-b " + " -b ".join(snakemake.config['qc']['fwd_adapters'])
+    if rev_adapters:
+        overlap = min(min(len(a) for a in rev_adapters), overlap)
+        rev_adapter_str = "-g " + " -g ".join(snakemake.config['qc']['rev_adapters'])
+    os.system("""
+    cutadapt --discard-trimmed -O {a} \
+    --cores {b} \
+    {c} {d} \
+    -o {e} \
+    {f} \
+    > {g} 2>&1
+    gzip {f}
+    """.format(a=overlap, b=snakemake.threads, c=fwd_adapter_str, d=rev_adapter_str, e=snakemake.params.tmp, f=snakemake.input,
+            g=snakemake.log))
+else:
+    os.system("""
+    ln -s {a} {b}
+    """.format(a=snakemake.input, b=snakemake.output))

--- a/scripts/qc/aggregate_reads.py
+++ b/scripts/qc/aggregate_reads.py
@@ -1,0 +1,6 @@
+import os
+
+if len(snakemake.input) == 0:
+    os.system("touch {0}".format(snakemake.output))
+else:
+    os.system("cat {0} > {1}".format(snakemake.input, snakemake.output))

--- a/scripts/qc/filter_reads.py
+++ b/scripts/qc/filter_reads.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+from collections import OrderedDict
+
+original = int(str(subprocess.getoutput(
+    "zcat {} | wc -l".format(snakemake.input.reads))).strip())//4
+host = int(subprocess.getoutput(
+    "cat {} | wc -l".format(snakemake.input.hostreads)).strip())
+nonhost = int(original-host)
+os.system("""
+gzip -dc {a} | \
+rbt fastq-filter {b} | \
+gzip > {c}
+""".format(a=snakemake.input.reads, b=snakemake.input.hostreads, c=snakemake.output.reads))
+
+hostdict = OrderedDict()
+for hostid in snakemake.input.hostids:
+    hostname = os.path.basename(os.path.dirname(hostid))
+    hostcts = int(subprocess.getoutput("cat {} | wc -l".format(hostid)).strip())
+    hostdict[hostname] = hostcts
+
+with open(snakemake.output.log, 'w') as log:
+    log.write("{}\n".format("\t".join(list(hostdict.keys()) + ["host","nonhost"] )))
+    log.write("{}\n".format("\t".join( map(str, list(hostdict.values()) + [host, nonhost]) )))

--- a/scripts/qc/get_mapped_reads.py
+++ b/scripts/qc/get_mapped_reads.py
@@ -1,0 +1,10 @@
+from sunbeamlib.decontam import get_mapped_reads
+
+with open(snakemake.output.ids, 'w') as out:
+    last = None
+    for read_id in get_mapped_reads(snakemake.input[0], snakemake.params.pct_id, snakemake.params.frac):
+        if read_id == last:
+            continue
+        else:
+            out.write(read_id + '\n')
+            last = read_id

--- a/scripts/qc/sample_intake.py
+++ b/scripts/qc/sample_intake.py
@@ -1,0 +1,7 @@
+from sunbeamlib import qc
+from pathlib import Path
+
+if snakemake.params.suffix:
+    qc.strip_seq_id_suffix(snakemake.input[0], snakemake.output[0], snakemake.params.suffix)
+else:
+    Path(snakemake.output[0]).symlink_to(snakemake.input[0])

--- a/scripts/reports/fastqc_report.py
+++ b/scripts/reports/fastqc_report.py
@@ -1,0 +1,6 @@
+import pandas
+from sunbeamlib import reports
+
+quality_list = [reports.parse_fastqc_quality(file) for file in snakemake.input.files]
+quality_table = pandas.concat(quality_list, axis=1).transpose()
+quality_table.to_csv(snakemake.output[0], sep="\t", index_label="Samples")

--- a/scripts/reports/multiqc_report.py
+++ b/scripts/reports/multiqc_report.py
@@ -4,5 +4,5 @@ report_name = snakemake.output[0].split('/')[-1]  # Get unique name from targets
 
 os.system("multiqc -i \"{a}\" -n {b} -o {c} {c}".format(
             a=snakemake.params.title, b=report_name, c=snakemake.params.outdir))
-os.rename(os.path.join(snakemake.params.outdir, "QC-report_multiqc_report.html"),
-        os.path.join(snakemake.params.outdir, report_name))
+#os.rename(os.path.join(snakemake.params.outdir, "QC-report_multiqc_report.html"),
+#        os.path.join(snakemake.params.outdir, report_name))

--- a/scripts/reports/multiqc_report.py
+++ b/scripts/reports/multiqc_report.py
@@ -1,0 +1,7 @@
+import os
+
+report_name = snakemake.output[0].split('/')[-1]  # Get unique name from targets.rules file
+print("THIS IS THE REPORT NAME: " + report_name)
+print("OUTPUT DIR: " + snakemake.params.outdir)
+os.system("multiqc -i \"{a}\" -n {b} -o {c} {c}".format(
+            a=snakemake.params.title, b=report_name, c=snakemake.params.outdir))

--- a/scripts/reports/multiqc_report.py
+++ b/scripts/reports/multiqc_report.py
@@ -1,7 +1,8 @@
 import os
 
 report_name = snakemake.output[0].split('/')[-1]  # Get unique name from targets.rules file
-print("THIS IS THE REPORT NAME: " + report_name)
-print("OUTPUT DIR: " + snakemake.params.outdir)
+
 os.system("multiqc -i \"{a}\" -n {b} -o {c} {c}".format(
             a=snakemake.params.title, b=report_name, c=snakemake.params.outdir))
+os.rename(os.path.join(snakemake.params.outdir, "QC-report_multiqc_report.html"),
+        os.path.join(snakemake.params.outdir, report_name))

--- a/scripts/reports/preprocess_report.py
+++ b/scripts/reports/preprocess_report.py
@@ -1,0 +1,9 @@
+import pandas
+from sunbeamlib import reports
+
+paired_end = snakemake.config['all']['paired_end']
+summary_list = [
+    reports.summarize_qual_decontam(q, d, paired_end) for q, d in 
+    zip(snakemake.input.trim_files, snakemake.input.decontam_files)]
+_reports = pandas.concat(summary_list)
+_reports.to_csv(snakemake.output[0], sep='\t', index_label='Samples')

--- a/sunbeamlib/config.py
+++ b/sunbeamlib/config.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import collections
+from collections.abc import Mapping
 from pathlib import Path
 from pkg_resources import resource_stream
 
@@ -91,7 +91,7 @@ def process_databases(db_dict):
 
 def _update_dict(target, new):
     for k, v in new.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, Mapping):
             # We could use .get() here but ruamel.yaml's weird Mapping
             # subclass outputs errors to stdout if the key doesn't exist
             if k in target:
@@ -104,7 +104,7 @@ def _update_dict(target, new):
 
 def _update_dict_strict(target, new):
     for k, v in new.items():
-        if isinstance(v, collections.Mapping) and k in target.keys():
+        if isinstance(v, Mapping) and k in target.keys():
             target[k] = _update_dict_strict(target.get(k, {}), v)
         elif k in target.keys():
             target[k] = v
@@ -164,7 +164,7 @@ def load_defaults(default_name):
         ).read().decode())
     
 def dump(config, out=sys.stdout):
-    if isinstance(config, collections.Mapping):
+    if isinstance(config, Mapping):
         ruamel.yaml.round_trip_dump(config, out)
     else:
         out.write(config)

--- a/sunbeamlib/scripts/run.py
+++ b/sunbeamlib/scripts/run.py
@@ -32,8 +32,9 @@ def main(argv=sys.argv):
             "Error: could not find a Snakefile in directory '{}'\n".format(
                 args.sunbeam_dir))
         sys.exit(1)
-        
-    snakemake_args = ['snakemake', '--snakefile', str(snakefile)] + remaining
+    
+    conda_prefix = Path(args.sunbeam_dir)/".snakemake"
+    snakemake_args = ['snakemake', '--snakefile', str(snakefile), '--use-conda', '--conda-prefix', str(conda_prefix), '-c'] + remaining
     print("Running: "+" ".join(snakemake_args))
 
     cmd = subprocess.run(snakemake_args)

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -117,7 +117,7 @@ function setup {
 	TEMPDIR=`mktemp -d`
     fi
     
-    verbose "\n\t${GREEN}Test directory${RESET}: ${TEMPDIR}"
+    verbose "\n\t${GREEN}Test directory${RESET}: ${TEMPDIR}\n"
 
     export PATH=$PATH:$HOME/miniconda3/bin
     # Allow conda [de]activate

--- a/tests/targets.txt
+++ b/tests/targets.txt
@@ -1,6 +1,6 @@
-annotation/blastn/bacteria/contig/dummybfragilis.xml
-annotation/blastn/bacteria/contig/dummyecoli.xml
-annotation/blastn/bacteria/contig/random.xml
+annotation/blastn/bacteria/contig/dummybfragilis.btf
+annotation/blastn/bacteria/contig/dummyecoli.btf
+annotation/blastn/bacteria/contig/random.btf
 
 annotation/summary/dummybfragilis.tsv
 annotation/summary/dummyecoli.tsv

--- a/tests/targets_singleend.txt
+++ b/tests/targets_singleend.txt
@@ -1,6 +1,6 @@
-annotation/blastn/bacteria/contig/dummybfragilis.xml
-annotation/blastn/bacteria/contig/dummyecoli.xml
-annotation/blastn/bacteria/contig/random.xml
+annotation/blastn/bacteria/contig/dummybfragilis.btf
+annotation/blastn/bacteria/contig/dummyecoli.btf
+annotation/blastn/bacteria/contig/random.btf
 
 annotation/summary/dummybfragilis.tsv
 annotation/summary/dummyecoli.tsv

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -1,6 +1,6 @@
 # Test normal behavior
 function test_all {
-    sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p
+    sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p -c4 --use-conda
 
     # Check contents
     annot_summary=sunbeam_output/annotation/summary/dummyecoli.tsv

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -1,6 +1,6 @@
 # Test normal behavior
 function test_all {
-    sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p --use-conda -c
+    sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p
 
     # Check contents
     annot_summary=sunbeam_output/annotation/summary/dummyecoli.tsv
@@ -30,7 +30,7 @@ function test_all_old_illumina {
     # Add config entry for suffix to remove from sequence IDs, and run just
     # like before.
     sed -i -r 's/^( +seq_id_ending: *).*$/\1"\/[12]"/' $TEMPDIR/tmp_config_old_illumina.yml
-    sunbeam run -- --configfile=$TEMPDIR/tmp_config_old_illumina.yml -p --use-conda -c
+    sunbeam run -- --configfile=$TEMPDIR/tmp_config_old_illumina.yml -p
     mv $TEMPDIR/samples_orig.csv $TEMPDIR/samples.csv
 
     # Check contents
@@ -52,7 +52,7 @@ function test_all_old_illumina {
 function test_optional_cutadapt {
     sed 's/adapters: \[.*\]/adapters: \[\]/g' $TEMPDIR/tmp_config.yml > $TEMPDIR/tmp_config_nocutadapt.yml
     rm -rf $TEMPDIR/sunbeam_output/qc
-    sunbeam run --configfile=$TEMPDIR/tmp_config_nocutadapt.yml all_decontam --use-conda -c
+    sunbeam run --configfile=$TEMPDIR/tmp_config_nocutadapt.yml all_decontam
     [ -f $TEMPDIR/sunbeam_output/qc/decontam/dummyecoli_1.fastq.gz ]
     [ -f $TEMPDIR/sunbeam_output/qc/decontam/dummyecoli_2.fastq.gz ]
 }
@@ -75,19 +75,19 @@ function test_version_check {
     sunbeam config modify --str 'all: {version: 9999.9.9}' \
 	    $TEMPDIR/tmp_config.yml > $TEMPDIR/too_high_config.yml
     # this should produce a nonzero exit code and fail if it does not
-    if sunbeam run --configfile $TEMPDIR/too_high_config.yml --use-conda -c; then
+    if sunbeam run --configfile $TEMPDIR/too_high_config.yml; then
 	exit 1
     fi
 }
 
 # Test that we detect and run extensions
 function test_extensions {
-    sunbeam run --configfile $TEMPDIR/tmp_config.yml sbx_test --use-conda -c | grep "SBX_TEST"
+    sunbeam run --configfile $TEMPDIR/tmp_config.yml sbx_test | grep "SBX_TEST"
 }
 
 # Test that we have the updated snakemake that uses "conda activate"
 #function test_use_conda {
-#    sunbeam run --configfile $TEMPDIR/tmp_config.yml --use-conda -c sbx_test | grep "SBX_TEST"
+#    sunbeam run --configfile $TEMPDIR/tmp_config.yml sbx_test | grep "SBX_TEST"
 #}
 
 # Test that single-end sequencing configurations work
@@ -103,7 +103,7 @@ function test_single_end {
 # Test that paired-end qc rules produce files with the same number of reads
 function test_pair_concordance {
     rm -rf $TEMPDIR/sunbeam_output/qc
-    sunbeam run --configfile $TEMPDIR/tmp_config.yml all_decontam --use-conda -c
+    sunbeam run --configfile $TEMPDIR/tmp_config.yml all_decontam
     for r1 in $TEMPDIR/sunbeam_output/qc/cleaned/*_1.fastq.gz; do
 	r1_lines=$(zcat $r1 | wc -l)
 	r2=${r1%_1.fastq.gz}_2.fastq.gz
@@ -164,7 +164,7 @@ function test_blank_fp_behavior {
     # with fasta files lying around in the top-level directory.
     sunbeam config modify --str 'mapping: {genomes_fp: ""}' \
         $TEMPDIR/tmp_config.yml > $TEMPDIR/blank_fp_config.yml
-    sunbeam run --configfile $TEMPDIR/blank_fp_config.yml --use-conda -c
+    sunbeam run --configfile $TEMPDIR/blank_fp_config.yml
     # Move indexes back to original location
     for file in $TEMPDIR/indexes_*; do
         mv $file ${file/indexes_/indexes\//}
@@ -221,7 +221,7 @@ function test_mapping {
     for file in $TEMPDIR/hosts/human*; do
         mv $file $TEMPDIR/hosts_${file##*/}
     done
-    sunbeam run --configfile $TEMPDIR/test_mapping_config.yml all_mapping --use-conda -c
+    sunbeam run --configfile $TEMPDIR/test_mapping_config.yml all_mapping
     # Move human host files back to original location
     for file in $TEMPDIR/hosts_*; do
         mv $file ${file/hosts_/hosts\//}
@@ -281,7 +281,7 @@ function test_get_paired_unpaired {
 # avoids this.
 function test_subdir_patterns {
     # All we need to check is that the graph resolution works.
-    sunbeam run --configfile $TEMPDIR/tmp_config.yml sbx_test_subdir -n --use-conda -c
+    sunbeam run --configfile $TEMPDIR/tmp_config.yml sbx_test_subdir -n
 }
 
 # Fix for #167:
@@ -291,7 +291,7 @@ function test_subdir_patterns {
 # Checking for successful behavior is already handled in test_all.
 function test_assembly_failures {
     # Up to just before the assembly rules, things should work fine.
-    sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p all_decontam --use-conda -c
+    sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p all_decontam
     # Remove previous assembly files, if they exist.
     rm -rf $TEMPDIR/sunbeam_output/assembly
     # If megahit gives an exit code != 0 and != 255 it is an error.
@@ -301,7 +301,7 @@ function test_assembly_failures {
     (
     export PATH="$TEMPDIR/megahit_137:$PATH"
     # (This command should *not* exit successfully.)
-    ! txt=$(sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p all_assembly --use-conda -c)
+    ! txt=$(sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p all_assembly)
     echo "$txt" | grep "Check your memory"
     )
     # If megahit exits with 255, it implies no contigs were built.
@@ -310,7 +310,7 @@ function test_assembly_failures {
     chmod +x $TEMPDIR/megahit_255/megahit
     (
     export PATH="$TEMPDIR/megahit_255:$PATH"
-    txt=$(sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p all_assembly --use-conda -c)
+    txt=$(sunbeam run -- --configfile=$TEMPDIR/tmp_config.yml -p all_assembly)
     echo "$txt" | grep "Empty contigs"
     )
 }
@@ -369,7 +369,7 @@ function test_extension_config_update {
 function test_all_sunbeam_extend {
     sunbeam extend https://github.com/sunbeam-labs/sbx_coassembly
     sunbeam config update -i $TEMPDIR/tmp_config.yml
-    sunbeam run --use-conda -c --configfile=$TEMPDIR/tmp_config.yml -p all_coassemble
+    sunbeam run -p all_coassemble
     test `ls $TEMPDIR/sunbeam_output/assembly | grep "coassembly" | wc -l` -eq 1
 }
 
@@ -385,5 +385,6 @@ function test_extend_trailing_slash {
 
 # Test that we detect and run extension rules using the smk extension (#196)
 function test_extension_smk {
-    sunbeam run --configfile $TEMPDIR/tmp_config.yml sbx_test_smk --use-conda -c | grep "SBX_TEST_SMK"
+    cat $TEMPDIR/tmp_config.yml
+    sunbeam run --configfile $TEMPDIR/tmp_config.yml sbx_test_smk | grep "SBX_TEST_SMK"
 }

--- a/tests/test_suite.bash
+++ b/tests/test_suite.bash
@@ -369,7 +369,7 @@ function test_extension_config_update {
 function test_all_sunbeam_extend {
     sunbeam extend https://github.com/sunbeam-labs/sbx_coassembly
     sunbeam config update -i $TEMPDIR/tmp_config.yml
-    sunbeam run --use-conda -c --configfile=$TEMPDIR/tmp_config.yml -p all_coassemble --use-conda -c
+    sunbeam run --use-conda -c --configfile=$TEMPDIR/tmp_config.yml -p all_coassemble
     test `ls $TEMPDIR/sunbeam_output/assembly | grep "coassembly" | wc -l` -eq 1
 }
 


### PR DESCRIPTION
* [ ] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

This should be merged after #318, changes blastx to diamond and uses Blast tab format instead of XML for all blast/diamond rules