### PR TITLE
252 qc summary doesnt include information on komplexity filtered reads

### DIFF
--- a/rules/reports/reports.smk
+++ b/rules/reports/reports.smk
@@ -15,7 +15,10 @@ rule preprocess_report:
             sample=sorted(Samples.keys())),
         decontam_files = expand(
             str(QC_FP/'log'/'decontam'/'{sample}_1.txt'),
-            sample=sorted(Samples.keys()))
+            sample=sorted(Samples.keys())),
+        komplexity_files = expand(
+            str(QC_FP/'log'/'komplexity'/'{sample}.filtered_ids'),
+            sample=sorted(Samples.keys())),
     output:
         str(QC_FP/'reports'/'preprocess_summary.tsv')
     conda:

--- a/scripts/reports/preprocess_report.py
+++ b/scripts/reports/preprocess_report.py
@@ -3,7 +3,7 @@ from sunbeamlib import reports
 
 paired_end = snakemake.config['all']['paired_end']
 summary_list = [
-    reports.summarize_qual_decontam(q, d, paired_end) for q, d in 
-    zip(snakemake.input.trim_files, snakemake.input.decontam_files)]
+    reports.summarize_qual_decontam(q, d, k, paired_end) for q, d, k in 
+    zip(snakemake.input.trim_files, snakemake.input.decontam_files, snakemake.input.komplexity_files)]
 _reports = pandas.concat(summary_list)
 _reports.to_csv(snakemake.output[0], sep='\t', index_label='Samples')

--- a/sunbeamlib/reports.py
+++ b/sunbeamlib/reports.py
@@ -56,10 +56,7 @@ def parse_decontam_log(f):
     return(OrderedDict(zip(keys,vals)))
 
 def parse_komplexity_log(f):
-    ret = list()
-    for line in f:
-        ret.append(line)
-    return ret
+    return OrderedDict([('komplexity', len(f.readlines()))])
 
 def summarize_qual_decontam(tfile, dfile, kfile, paired_end):
     """Return a dataframe for summary information for trimmomatic and decontam rule"""
@@ -78,7 +75,7 @@ def summarize_qual_decontam(tfile, dfile, kfile, paired_end):
     sys.stderr.write("trim data: {}\n".format(trim_data))
     sys.stderr.write("decontam data: {}\n".format(decontam_data))
     sys.stderr.write("komplexity data: {}\n".format(komplexity_data))
-    return(pandas.DataFrame(OrderedDict(trim_data, **(decontam_data)), index=[tname]))
+    return(pandas.DataFrame(OrderedDict(trim_data, **(decontam_data), **(komplexity_data)), index=[tname]))
 
 def parse_fastqc_quality(filename):
     with open(filename) as f:

--- a/sunbeamlib/reports.py
+++ b/sunbeamlib/reports.py
@@ -55,20 +55,29 @@ def parse_decontam_log(f):
     vals = f.readline().rstrip().split('\t')
     return(OrderedDict(zip(keys,vals)))
 
-def summarize_qual_decontam(tfile, dfile, paired_end):
+def parse_komplexity_log(f):
+    ret = list()
+    for line in f:
+        ret.append(line)
+    return ret
+
+def summarize_qual_decontam(tfile, dfile, kfile, paired_end):
     """Return a dataframe for summary information for trimmomatic and decontam rule"""
     tname = os.path.basename(tfile).split('.out')[0]
-    dname = os.path.basename(dfile).split('.txt')[0]
     with open(tfile) as tf:
         with open(dfile) as jf:
-            if paired_end:
-                trim_data = parse_trim_summary_paired(tf)
-            else:
-                trim_data = parse_trim_summary_single(tf)
-                
-            decontam_data = parse_decontam_log(jf)
+            with open(kfile) as kf:
+                if paired_end:
+                    trim_data = parse_trim_summary_paired(tf)
+                else:
+                    trim_data = parse_trim_summary_single(tf)
+                    
+                decontam_data = parse_decontam_log(jf)
+
+                komplexity_data = parse_komplexity_log(kf)
     sys.stderr.write("trim data: {}\n".format(trim_data))
     sys.stderr.write("decontam data: {}\n".format(decontam_data))
+    sys.stderr.write("komplexity data: {}\n".format(komplexity_data))
     return(pandas.DataFrame(OrderedDict(trim_data, **(decontam_data)), index=[tname]))
 
 def parse_fastqc_quality(filename):


### PR DESCRIPTION
* [ ] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
