### PR TITLE
Remove strs

### DIFF
--- a/rules/annotation/annotation.smk
+++ b/rules/annotation/annotation.smk
@@ -11,17 +11,17 @@ rule all_annotate:
 
 rule aggregate_results:
     input:
-        contigs=str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa'),
+        contigs=ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa',
         contig_results=expand(
-            str(ANNOTATION_FP/'blastn'/'{db}'/'contig'/'{{sample}}.btf'),
+            ANNOTATION_FP/'blastn'/'{db}'/'contig'/'{{sample}}.btf',
             db=Blastdbs['nucl']),
         gene_results=expand(
-            str(ANNOTATION_FP/'{blastpx}'/'{db}'/'{orf_finder}'/'{{sample}}.btf'),
+            ANNOTATION_FP/'{blastpx}'/'{db}'/'{orf_finder}'/'{{sample}}.btf',
             blastpx=['blastp','blastx'],
             db=Blastdbs['prot'],
             orf_finder=['prodigal'])
     output:
-        str(ANNOTATION_FP/'summary'/'{sample}.tsv')
+        ANNOTATION_FP/'summary'/'{sample}.tsv'
     params:
         dbs=list(Blastdbs['nucl'].keys()) + list(Blastdbs['prot'].keys()),
         nucl = Blastdbs['nucl'],
@@ -34,10 +34,10 @@ rule aggregate_results:
 rule aggregate_all:
     input:
         expand(
-            str(ANNOTATION_FP/'summary'/'{sample}.tsv'),
+            ANNOTATION_FP/'summary'/'{sample}.tsv',
             sample=Samples.keys())
     output:
-        str(ANNOTATION_FP/'all_samples.tsv')
+        ANNOTATION_FP/'all_samples.tsv'
     run:
         with open(output[0], 'w') as out:
             out.writelines(open(input[0]).readlines())

--- a/rules/annotation/blast.smk
+++ b/rules/annotation/blast.smk
@@ -21,9 +21,9 @@ rule build_diamond_db:
 rule run_blastn:
     """Run BLASTn against a given database and write the results to blast tabular format."""    
     input:
-        contigs=str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa')
+        contigs=ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa'
     output:
-        str(ANNOTATION_FP/'blastn'/'{db}'/'{contigs}'/'{sample}.btf')
+        ANNOTATION_FP/'blastn'/'{db}'/'{contigs}'/'{sample}.btf'
     params:
         db=lambda wildcard: Blastdbs['nucl'][wildcard.db] 
     threads: 
@@ -45,11 +45,11 @@ rule run_blastn:
 rule run_diamond_blastp:
     """Run diamond blastp on translated genes against a target db and write to blast tabular format."""
     input:
-        genes=str(ANNOTATION_FP/'genes'/'{orf_finder}'/'{sample}_genes_prot.fa'),
+        genes=ANNOTATION_FP/'genes'/'{orf_finder}'/'{sample}_genes_prot.fa',
         db=lambda wildcard: Blastdbs['prot'][wildcard.db],
         indeces=rules.build_diamond_db.output
     output:
-        str(ANNOTATION_FP/'blastp'/'{db}'/'{orf_finder}'/'{sample}.btf')
+        ANNOTATION_FP/'blastp'/'{db}'/'{orf_finder}'/'{sample}.btf'
     threads:
         Cfg['blast']['threads']
     conda:
@@ -70,11 +70,11 @@ rule run_diamond_blastp:
 rule run_diamond_blastx:
     """Run diamond blastx on untranslated genes against a target db and write to blast tabular format."""
     input:
-        genes=str(ANNOTATION_FP/'genes'/'{orf_finder}'/'{sample}_genes_nucl.fa'),
+        genes=ANNOTATION_FP/'genes'/'{orf_finder}'/'{sample}_genes_nucl.fa',
         db=lambda wildcard: Blastdbs['prot'][wildcard.db],
         indeces=rules.build_diamond_db.output
     output:
-        str(ANNOTATION_FP/'blastx'/'{db}'/'{orf_finder}'/'{sample}.btf')
+        ANNOTATION_FP/'blastx'/'{db}'/'{orf_finder}'/'{sample}.btf'
     threads:
         Cfg['blast']['threads']
     conda:
@@ -96,10 +96,10 @@ rule blast_report:
     """Create a summary of results from a BLAST call."""
     input:
         expand(
-            str(ANNOTATION_FP/'{{blast_prog}}'/'{{db}}'/'{{query}}'/'{sample}.btf'),
+            ANNOTATION_FP/'{{blast_prog}}'/'{{db}}'/'{{query}}'/'{sample}.btf',
             sample=Samples.keys())
     output:
-        str(ANNOTATION_FP/'{blast_prog}'/'{db}'/'{query}'/'report.tsv')
+        ANNOTATION_FP/'{blast_prog}'/'{db}'/'{query}'/'report.tsv'
     conda:
         "../../envs/annotation.yml"
     script:
@@ -107,11 +107,11 @@ rule blast_report:
 
 rule _test_blastpx:
     input:
-        expand(str(ANNOTATION_FP/'{blastpx}'/'card'/'prodigal'/'{sample}.btf'), 
+        expand(ANNOTATION_FP/'{blastpx}'/'card'/'prodigal'/'{sample}.btf', 
                blastpx=['blastx','blastp'], sample=Samples.keys())
     
 rule _test_blastpx_report:
     input:
-        expand(str(ANNOTATION_FP/'{blastpx}'/'card'/'prodigal'/'report.tsv'),
+        expand(ANNOTATION_FP/'{blastpx}'/'card'/'prodigal'/'report.tsv',
         blastpx=['blastx','blastp'])
 

--- a/rules/annotation/orf.smk
+++ b/rules/annotation/orf.smk
@@ -9,12 +9,12 @@
 rule prodigal:
     """Use Progial for coding genes predictions in contigs."""
     input:
-        str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa')
+        ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa'
     output:
-        gff = str(ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes.gff'),
-        faa = str(ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes_prot.fa'),
-        fna = str(ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes_nucl.fa'),
-        log = str(ANNOTATION_FP/'genes'/'prodigal'/'log'/'{sample}.out')
+        gff = ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes.gff',
+        faa = ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes_prot.fa',
+        fna = ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes_nucl.fa',
+        log = ANNOTATION_FP/'genes'/'prodigal'/'log'/'{sample}.out'
     conda:
         "../../envs/annotation.yml"
     shell:
@@ -32,7 +32,7 @@ rule prodigal:
 
 rule _test_prodigal:
     input:
-        expand(str(ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes_{suffix}.fa'),
+        expand(ANNOTATION_FP/'genes'/'prodigal'/'{sample}_genes_{suffix}.fa',
         sample=Samples.keys(), suffix=['prot','nucl'])
 
 

--- a/rules/assembly/assembly.smk
+++ b/rules/assembly/assembly.smk
@@ -13,12 +13,12 @@ ruleorder: megahit_paired > megahit_unpaired
 
 rule megahit_paired:
     input:
-        r1 = str(QC_FP/'decontam'/'{sample}_1.fastq.gz'),
-        r2 = str(QC_FP/'decontam'/'{sample}_2.fastq.gz')
+        r1 = QC_FP/'decontam'/'{sample}_1.fastq.gz',
+        r2 = QC_FP/'decontam'/'{sample}_2.fastq.gz'
     output:
-        str(ASSEMBLY_FP/'megahit'/'{sample}_asm'/'final.contigs.fa')
+        ASSEMBLY_FP/'megahit'/'{sample}_asm'/'final.contigs.fa'
     params:
-        out_fp = str(ASSEMBLY_FP/'megahit'/'{sample}_asm')
+        out_fp = ASSEMBLY_FP/'megahit'/'{sample}_asm'
     threads:
         Cfg['assembly']['threads']
     conda:
@@ -48,11 +48,11 @@ rule megahit_paired:
 
 rule megahit_unpaired:
     input:
-        str(QC_FP/'decontam'/'{sample}_1.fastq.gz')
+        QC_FP/'decontam'/'{sample}_1.fastq.gz'
     output:
-        str(ASSEMBLY_FP/'megahit'/'{sample}_asm'/'final.contigs.fa')
+        ASSEMBLY_FP/'megahit'/'{sample}_asm'/'final.contigs.fa'
     params:
-        out_fp = str(ASSEMBLY_FP/'megahit'/'{sample}_asm')
+        out_fp = ASSEMBLY_FP/'megahit'/'{sample}_asm'
     threads:
         Cfg['assembly']['threads']
     conda:
@@ -78,13 +78,13 @@ rule megahit_unpaired:
 
 rule final_filter:
     input:
-        str(ASSEMBLY_FP/'megahit'/'{sample}_asm'/'final.contigs.fa')
+        ASSEMBLY_FP/'megahit'/'{sample}_asm'/'final.contigs.fa'
     output:
-        str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa')
+        ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa'
     params:
         len = Cfg['assembly']['min_length']
     log:
-        str(ASSEMBLY_FP/'log'/'vsearch'/'{sample}.log')
+        ASSEMBLY_FP/'log'/'vsearch'/'{sample}.log'
     conda:
         "../../envs/assembly.yml"
     script:
@@ -92,7 +92,7 @@ rule final_filter:
 
 rule clean_assembly:
     input:
-        M = str(ASSEMBLY_FP/'megahit'),
+        M = ASSEMBLY_FP/'megahit',
     shell:
         """
         rm -rf {input.M} && echo "Cleanup assembly finished."

--- a/rules/assembly/assembly.smk
+++ b/rules/assembly/assembly.smk
@@ -18,7 +18,7 @@ rule megahit_paired:
     output:
         ASSEMBLY_FP/'megahit'/'{sample}_asm'/'final.contigs.fa'
     params:
-        out_fp = ASSEMBLY_FP/'megahit'/'{sample}_asm'
+        out_fp = str(ASSEMBLY_FP/'megahit'/'{sample}_asm')
     threads:
         Cfg['assembly']['threads']
     conda:

--- a/rules/assembly/assembly.smk
+++ b/rules/assembly/assembly.smk
@@ -52,7 +52,7 @@ rule megahit_unpaired:
     output:
         ASSEMBLY_FP/'megahit'/'{sample}_asm'/'final.contigs.fa'
     params:
-        out_fp = ASSEMBLY_FP/'megahit'/'{sample}_asm'
+        out_fp = str(ASSEMBLY_FP/'megahit'/'{sample}_asm')
     threads:
         Cfg['assembly']['threads']
     conda:

--- a/rules/assembly/coverage.smk
+++ b/rules/assembly/coverage.smk
@@ -6,27 +6,27 @@
 
 rule all_coverage:
     input:
-        str(ASSEMBLY_FP/'contigs_coverage.txt')
+        ASSEMBLY_FP/'contigs_coverage.txt'
 
 rule _contigs_mapping:
     input:
-        expand(str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth'),
+        expand(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth',
                sample=Samples.keys())        
 
 rule _all_coverage:
     input:
-        expand(str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv'),
+        expand(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv',
                sample=Samples.keys())
 
 rule contigs_mapping:
     input:
-        contig = str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa'),
-        reads = expand(str(QC_FP/'decontam'/'{{sample}}_{rp}.fastq.gz'),rp = Pairs)
+        contig = ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa',
+        reads = expand(QC_FP/'decontam'/'{{sample}}_{rp}.fastq.gz',rp = Pairs)
     output:
-        bam = str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam'),
-        bai = str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam.bai')
+        bam = ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam',
+        bai = ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam.bai'
     params:
-        temp = temp(str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.tmp'))
+        temp = temp(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.tmp')
     threads: 
         Cfg['mapping']['threads']
     conda:
@@ -40,10 +40,10 @@ rule contigs_mapping:
 
 rule mapping_depth:
     input:
-        bam = str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam'),
-        bai = str(ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam.bai')
+        bam = ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam',
+        bai = ASSEMBLY_FP/'contigs'/'minimap2'/'{sample}.sorted.bam.bai'
     output:
-        depth = str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth')
+        depth = ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth'
     conda:
         "../../envs/assembly.yml"
     shell:
@@ -54,9 +54,9 @@ rule mapping_depth:
 
 rule get_coverage:
     input:
-        str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth')
+        ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.depth'
     output:
-        str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv')
+        ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv'
     conda:
         "../../envs/assembly.yml"
     script:
@@ -65,10 +65,10 @@ rule get_coverage:
 
 rule summarize_coverage:
     input:
-        expand(str(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv'), 
+        expand(ASSEMBLY_FP/'contigs'/'coverage'/'{sample}.csv', 
                sample = Samples.keys())
     output:
-        str(ASSEMBLY_FP/'contigs_coverage.txt')
+        ASSEMBLY_FP/'contigs_coverage.txt'
     shell:
         "(head -n 1 {input[0]}; tail -q -n +2 {input}) > {output}"
 

--- a/rules/classify/kraken.smk
+++ b/rules/classify/kraken.smk
@@ -8,10 +8,10 @@ rule all_classify:
         
 rule kraken2_classify_report:
     input:
-        expand(str(QC_FP/'decontam'/'{{sample}}_{rp}.fastq.gz'),rp = Pairs)
+        expand(QC_FP/'decontam'/'{{sample}}_{rp}.fastq.gz',rp = Pairs)
     output:
-        raw = str(CLASSIFY_FP/'kraken'/'raw'/'{sample}-raw.tsv'),
-        report = str(CLASSIFY_FP/'kraken'/'{sample}-taxa.tsv')
+        raw = CLASSIFY_FP/'kraken'/'raw'/'{sample}-raw.tsv',
+        report = CLASSIFY_FP/'kraken'/'{sample}-taxa.tsv'
     params:
         db = Cfg['classify']['kraken_db_fp'],
         paired_end = "--paired" if Cfg['all']['paired_end'] else ""
@@ -28,10 +28,10 @@ rule kraken2_classify_report:
 
 rule kraken2_biom:
     input:
-        expand(str(CLASSIFY_FP/'kraken'/'{sample}-taxa.tsv'),
+        expand(CLASSIFY_FP/'kraken'/'{sample}-taxa.tsv',
                sample=Samples.keys())
     output:
-        str(CLASSIFY_FP/'kraken'/'all_samples.biom')
+        CLASSIFY_FP/'kraken'/'all_samples.biom'
     shell:
         # Using pip to install because conda version is way outdated
         """
@@ -42,9 +42,9 @@ rule kraken2_biom:
 
 rule classic_k2_biom:
     input:
-        str(CLASSIFY_FP/'kraken'/'all_samples.biom')
+        CLASSIFY_FP/'kraken'/'all_samples.biom'
     output:
-        str(CLASSIFY_FP/'kraken'/'all_samples.tsv')
+        CLASSIFY_FP/'kraken'/'all_samples.tsv'
     conda:
         "../../envs/classify.yml"
     shell:

--- a/rules/download/download.smk
+++ b/rules/download/download.smk
@@ -6,11 +6,11 @@ ruleorder: download_paired > download_unpaired
 
 rule download_paired:
     output:
-        r1 = str(DOWNLOAD_FP/'{sample}_1.fastq.gz'),
-        r2 = str(DOWNLOAD_FP/'{sample}_2.fastq.gz')
+        r1 = DOWNLOAD_FP/'{sample}_1.fastq.gz',
+        r2 = DOWNLOAD_FP/'{sample}_2.fastq.gz'
     params:
         accession = '{sample}',
-        outdir = str(DOWNLOAD_FP)
+        outdir = DOWNLOAD_FP
     threads:
         Cfg['download']['threads']
     shadow: "shallow"
@@ -24,10 +24,10 @@ rule download_paired:
 
 rule download_unpaired:
     output:
-        str(DOWNLOAD_FP/'{sample}.fastq.gz')
+        DOWNLOAD_FP/'{sample}.fastq.gz'
     params:
         accession = '{sample}',
-        outdir = str(DOWNLOAD_FP)
+        outdir = DOWNLOAD_FP
     threads:
         Cfg['download']['threads']	
     shadow: "shallow"

--- a/rules/mapping/mapping.smk
+++ b/rules/mapping/mapping.smk
@@ -5,9 +5,9 @@ rule all_mapping:
 
 rule build_genome_index:
     input:
-        str(Cfg['mapping']['genomes_fp']/'{genome}.fasta')
+        Cfg['mapping']['genomes_fp']/'{genome}.fasta'
     output:
-        str(Cfg['mapping']['genomes_fp']/'{genome}.fasta.amb')
+        Cfg['mapping']['genomes_fp']/'{genome}.fasta.amb'
     conda:
         "../../envs/mapping.yml"
     shell:
@@ -16,15 +16,15 @@ rule build_genome_index:
 rule align_to_genome:
     input:
         reads = expand(
-            str(QC_FP/'decontam'/'{{sample}}_{rp}.fastq.gz'),
+            QC_FP/'decontam'/'{{sample}}_{rp}.fastq.gz',
             rp = Pairs),
-        index = str(Cfg['mapping']['genomes_fp']/'{genome}.fasta.amb')
+        index = Cfg['mapping']['genomes_fp']/'{genome}.fasta.amb'
     output:
-        temp(str(MAPPING_FP/'intermediates'/'{genome}'/'{sample}.sam'))
+        temp(MAPPING_FP/'intermediates'/'{genome}'/'{sample}.sam')
     threads:
         Cfg['mapping']['threads']
     params:
-        index_fp = str(Cfg['mapping']['genomes_fp'])
+        index_fp = Cfg['mapping']['genomes_fp']
     conda:
         "../../envs/mapping.yml"
     shell:
@@ -36,9 +36,9 @@ rule align_to_genome:
 
 rule samtools_convert:
     input:
-        str(MAPPING_FP/'intermediates'/'{genome}'/'{sample}.sam')
+        MAPPING_FP/'intermediates'/'{genome}'/'{sample}.sam'
     output:
-        str(MAPPING_FP/'{genome}'/'{sample}.bam')
+        MAPPING_FP/'{genome}'/'{sample}.bam'
     threads:
         Cfg['mapping']['threads']
     conda:
@@ -50,29 +50,29 @@ rule samtools_convert:
         """
 
 def _sorted_csvs(w):
-    pattern = str(MAPPING_FP/'intermediates'/w.genome/'{sample}.csv')
+    pattern = MAPPING_FP/'intermediates'/w.genome/'{sample}.csv'
     paths = sorted(expand(pattern, sample=Samples.keys()))
     return(paths)
 
 rule samtools_summarize_coverage:
     input: _sorted_csvs
     output:
-        str(MAPPING_FP/'{genome}'/'coverage.csv')
+        MAPPING_FP/'{genome}'/'coverage.csv'
     shell: "(head -n 1 {input[0]}; tail -q -n +2 {input}) > {output}"
 
 rule samtools_get_coverage:
     input:
-        str(MAPPING_FP/'{genome}'/'{sample}.bam')
+        MAPPING_FP/'{genome}'/'{sample}.bam'
     output:
-        str(MAPPING_FP/'intermediates'/'{genome}'/'{sample}.csv')
+        MAPPING_FP/'intermediates'/'{genome}'/'{sample}.csv'
     conda:
         "../../envs/mapping.yml"
     script:
         "../../scripts/mapping/samtools_get_coverage.py"
 
 rule samtools_index:
-    input: str(MAPPING_FP/'{genome}'/'{sample}.bam')
-    output: str(MAPPING_FP/'{genome}'/'{sample}.bam.bai')
+    input: MAPPING_FP/'{genome}'/'{sample}.bam'
+    output: MAPPING_FP/'{genome}'/'{sample}.bam.bai'
     conda:
         "../../envs/mapping.yml"
     shell:
@@ -81,9 +81,9 @@ rule samtools_index:
            
 rule samtools_mpileup:
     input:
-        bam = str(MAPPING_FP/'{genome}'/'{sample}.bam'),
-        genome = str(Cfg['mapping']['genomes_fp']/'{genome}.fasta')
-    output: str(MAPPING_FP/'{genome}'/'{sample}.raw.bcf')
+        bam = MAPPING_FP/'{genome}'/'{sample}.bam',
+        genome = Cfg['mapping']['genomes_fp']/'{genome}.fasta'
+    output: MAPPING_FP/'{genome}'/'{sample}.raw.bcf'
     conda:
         "../../envs/mapping.yml"
     shell:

--- a/rules/qc/decontaminate.smk
+++ b/rules/qc/decontaminate.smk
@@ -1,19 +1,19 @@
 rule all_decontam:
     input:
         expand(
-            str(QC_FP/'decontam'/'{sample}_{rp}.fastq.gz'),
+            QC_FP/'decontam'/'{sample}_{rp}.fastq.gz',
             sample=Samples.keys(), rp=Pairs)
 
 ruleorder: build_host_index > build_genome_index
         
 rule build_host_index:
     input:
-        str(Cfg['qc']['host_fp']/'{host}.fasta')
+        Cfg['qc']['host_fp']/'{host}.fasta'
     output:
-        str(Cfg['qc']['host_fp']/'{host}.fasta.amb')
+        Cfg['qc']['host_fp']/'{host}.fasta.amb'
     params:
         host='{host}',
-        index_fp=str(Cfg['qc']['host_fp'])
+        index_fp=Cfg['qc']['host_fp']
     conda:
         "../../envs/qc.yml"
     shell:
@@ -22,16 +22,16 @@ rule build_host_index:
 rule align_to_host:
     input:
         reads = expand(
-            str(QC_FP/'cleaned'/'{{sample}}_{rp}.fastq.gz'),
+            QC_FP/'cleaned'/'{{sample}}_{rp}.fastq.gz',
             rp = Pairs),
-        index = str(Cfg['qc']['host_fp']/'{host}.fasta.amb')
+        index = Cfg['qc']['host_fp']/'{host}.fasta.amb'
     output:
-        temp(str(QC_FP/'decontam'/'intermediates'/'{host}'/'{sample}.bam'))
+        temp(QC_FP/'decontam'/'intermediates'/'{host}'/'{sample}.bam')
     threads:
         Cfg['qc']['threads']
     params:
-        sam = temp(str(QC_FP/'decontam'/'intermediates'/'{host}'/'{sample}.sam')),
-        index_fp = str(Cfg['qc']['host_fp'])
+        sam = temp(QC_FP/'decontam'/'intermediates'/'{host}'/'{sample}.sam'),
+        index_fp = Cfg['qc']['host_fp']
     conda:
         "../../envs/qc.yml"
     shell:
@@ -45,9 +45,9 @@ rule align_to_host:
 
 rule get_mapped_reads:
     input:
-        str(QC_FP/'decontam'/'intermediates'/'{host}'/'{sample}.bam')
+        QC_FP/'decontam'/'intermediates'/'{host}'/'{sample}.bam'
     output:
-        ids = str(QC_FP/'decontam'/'intermediates'/'{host}'/'{sample}.ids'),
+        ids = QC_FP/'decontam'/'intermediates'/'{host}'/'{sample}.ids',
     params:
         pct_id =  Cfg['qc']['pct_id'],
         frac = Cfg['qc']['frac']
@@ -59,21 +59,21 @@ rule get_mapped_reads:
 rule aggregate_reads:
     input:
         expand(
-            str(QC_FP/'decontam'/'intermediates'/'{host}'/'{{sample}}.ids'),
+            QC_FP/'decontam'/'intermediates'/'{host}'/'{{sample}}.ids',
             host=HostGenomes.keys())
     output:
-        temp(str(QC_FP/'decontam'/'intermediates'/'{sample}_hostreads.ids')),
+        temp(QC_FP/'decontam'/'intermediates'/'{sample}_hostreads.ids'),
     script:
         "../../scripts/qc/aggregate_reads.py"
 
 rule filter_reads:
     input:
-        hostreads = str(QC_FP/'decontam'/'intermediates'/'{sample}_hostreads.ids'),
-        reads = str(QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz'),
-        hostids = expand(str(QC_FP/'decontam'/'intermediates'/'{host}'/'{{sample}}.ids'), host=HostGenomes.keys())
+        hostreads = QC_FP/'decontam'/'intermediates'/'{sample}_hostreads.ids',
+        reads = QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz',
+        hostids = expand(QC_FP/'decontam'/'intermediates'/'{host}'/'{{sample}}.ids', host=HostGenomes.keys())
     output:
-        reads = str(QC_FP/'decontam'/'{sample}_{rp}.fastq.gz'),
-        log = str(QC_FP/'log'/'decontam'/'{sample}_{rp}.txt')
+        reads = QC_FP/'decontam'/'{sample}_{rp}.fastq.gz',
+        log = QC_FP/'log'/'decontam'/'{sample}_{rp}.txt'
     conda:
         "../../envs/qc.yml"
     script:

--- a/rules/qc/qc.smk
+++ b/rules/qc/qc.smk
@@ -43,8 +43,8 @@ rule adapter_removal_paired:
         r1 = QC_FP/'00_samples'/'{sample}_1.fastq.gz',
         r2 = QC_FP/'00_samples'/'{sample}_2.fastq.gz'
     params:
-        r1 = QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz',
-        r2 = QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz'
+        r1 = str(QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz'),
+        r2 = str(QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz')
     log: QC_FP/'log'/'cutadapt'/'{sample}.log'
     output:
         gr1 = QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz',

--- a/rules/qc/qc.smk
+++ b/rules/qc/qc.smk
@@ -27,7 +27,7 @@ rule adapter_removal_unpaired:
     input:
         QC_FP/'00_samples'/'{sample}_1.fastq.gz'
     params:
-        tmp = QC_FP/'01_cutadapt'/'{sample}_1.fastq',
+        tmp = str(QC_FP/'01_cutadapt'/'{sample}_1.fastq'),
     log: QC_FP/'log'/'cutadapt'/'{sample}.log'
     output:
         QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz'

--- a/rules/qc/qc.smk
+++ b/rules/qc/qc.smk
@@ -15,7 +15,7 @@ rule sample_intake:
     input:
         lambda wildcards: Samples[wildcards.sample][wildcards.rp]
     output:
-        str(QC_FP/'00_samples'/'{sample}_{rp}.fastq.gz')
+        QC_FP/'00_samples'/'{sample}_{rp}.fastq.gz'
     params:
         suffix = Cfg['qc']['seq_id_ending']
     conda:
@@ -25,12 +25,12 @@ rule sample_intake:
 
 rule adapter_removal_unpaired:
     input:
-        str(QC_FP/'00_samples'/'{sample}_1.fastq.gz')
+        QC_FP/'00_samples'/'{sample}_1.fastq.gz'
     params:
-        tmp = str(QC_FP/'01_cutadapt'/'{sample}_1.fastq'),
-    log: str(QC_FP/'log'/'cutadapt'/'{sample}.log') 
+        tmp = QC_FP/'01_cutadapt'/'{sample}_1.fastq',
+    log: QC_FP/'log'/'cutadapt'/'{sample}.log'
     output:
-        str(QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz')
+        QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz'
     threads:
         Cfg['qc']['threads']
     conda:
@@ -40,15 +40,15 @@ rule adapter_removal_unpaired:
     
 rule adapter_removal_paired:
     input:
-        r1 = str(QC_FP/'00_samples'/'{sample}_1.fastq.gz'),
-        r2 = str(QC_FP/'00_samples'/'{sample}_2.fastq.gz')
+        r1 = QC_FP/'00_samples'/'{sample}_1.fastq.gz',
+        r2 = QC_FP/'00_samples'/'{sample}_2.fastq.gz'
     params:
-        r1 = str(QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz'),
-        r2 = str(QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz')
-    log: str(QC_FP/'log'/'cutadapt'/'{sample}.log') 
+        r1 = QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz',
+        r2 = QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz'
+    log: QC_FP/'log'/'cutadapt'/'{sample}.log'
     output:
-        gr1 = str(QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz'),
-        gr2 = str(QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz')
+        gr1 = QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz',
+        gr2 = QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz'
     threads:
         Cfg['qc']['threads']
     conda:
@@ -60,10 +60,10 @@ ruleorder: trimmomatic_paired > trimmomatic_unpaired
         
 rule trimmomatic_unpaired:
     input:
-        str(QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz')
+        QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz'
     output:
-        str(QC_FP/'02_trimmomatic'/'{sample}_1.fastq.gz')
-    log: str(QC_FP/'log'/'trimmomatic'/'{sample}.out')
+        QC_FP/'02_trimmomatic'/'{sample}_1.fastq.gz'
+    log: QC_FP/'log'/'trimmomatic'/'{sample}.out'
     params:
         sw_start = Cfg['qc']['slidingwindow'][0],
         sw_end = Cfg['qc']['slidingwindow'][1]
@@ -87,14 +87,14 @@ rule trimmomatic_unpaired:
             
 rule trimmomatic_paired:
     input:
-        r1 = str(QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz'),
-        r2 = str(QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz')
+        r1 = QC_FP/'01_cutadapt'/'{sample}_1.fastq.gz',
+        r2 = QC_FP/'01_cutadapt'/'{sample}_2.fastq.gz'
     output:
-        pair_r1 = str(QC_FP/'02_trimmomatic'/'{sample}_1.fastq.gz'),
-        pair_r2 = str(QC_FP/'02_trimmomatic'/'{sample}_2.fastq.gz'),
-        unpair_r1 = temp(str(QC_FP/'02_trimmomatic'/'unpaired'/'{sample}_1_unpaired.fastq.gz')),
-        unpair_r2 = temp(str(QC_FP/'02_trimmomatic'/'unpaired'/'{sample}_2_unpaired.fastq.gz'))
-    log: str(QC_FP/'log'/'trimmomatic'/'{sample}.out'),
+        pair_r1 = QC_FP/'02_trimmomatic'/'{sample}_1.fastq.gz',
+        pair_r2 = QC_FP/'02_trimmomatic'/'{sample}_2.fastq.gz',
+        unpair_r1 = temp(QC_FP/'02_trimmomatic'/'unpaired'/'{sample}_1_unpaired.fastq.gz'),
+        unpair_r2 = temp(QC_FP/'02_trimmomatic'/'unpaired'/'{sample}_2_unpaired.fastq.gz')
+    log: QC_FP/'log'/'trimmomatic'/'{sample}.out',
     params:
         sw_start = Cfg['qc']['slidingwindow'][0],
         sw_end = Cfg['qc']['slidingwindow'][1]
@@ -120,14 +120,14 @@ rule trimmomatic_paired:
 rule fastqc:
     input:
         reads = expand(
-            str(QC_FP/"02_trimmomatic"/"{{sample}}_{rp}.fastq.gz"),
+            QC_FP/"02_trimmomatic"/"{{sample}}_{rp}.fastq.gz",
             rp=Pairs)
     output:
         expand(
-            str(QC_FP/'reports'/'{{sample}}_{rp}_fastqc/fastqc_data.txt'),
+            QC_FP/'reports'/'{{sample}}_{rp}_fastqc/fastqc_data.txt',
             rp=Pairs)
     params:
-        outdir = str(QC_FP/'reports')
+        outdir = QC_FP/'reports'
     conda:
         "../../envs/qc.yml"
     shell:
@@ -136,10 +136,10 @@ rule fastqc:
 rule find_low_complexity:
     input:
         expand(
-            str(QC_FP/'02_trimmomatic'/'{{sample}}_{rp}.fastq.gz'),
+            QC_FP/'02_trimmomatic'/'{{sample}}_{rp}.fastq.gz',
             rp=Pairs)
     output:
-        str(QC_FP/'log'/'komplexity'/'{sample}.filtered_ids')
+        QC_FP/'log'/'komplexity'/'{sample}.filtered_ids'
     conda:
         "../../envs/qc.yml"
     shell:
@@ -152,10 +152,10 @@ rule find_low_complexity:
 
 rule remove_low_complexity:
     input:
-        reads = str(QC_FP/'02_trimmomatic'/'{sample}_{rp}.fastq.gz'),
-        ids = str(QC_FP/'log'/'komplexity'/'{sample}.filtered_ids')
+        reads = QC_FP/'02_trimmomatic'/'{sample}_{rp}.fastq.gz',
+        ids = QC_FP/'log'/'komplexity'/'{sample}.filtered_ids'
     output:
-        str(QC_FP/'03_komplexity'/'{sample}_{rp}.fastq.gz')
+        QC_FP/'03_komplexity'/'{sample}_{rp}.fastq.gz'
     conda:
         "../../envs/qc.yml"
     shell:
@@ -166,21 +166,21 @@ rule remove_low_complexity:
 
 rule qc_final:
     input:
-        str(QC_FP/'03_komplexity'/'{sample}_{rp}.fastq.gz')
+        QC_FP/'03_komplexity'/'{sample}_{rp}.fastq.gz'
     output:
-        str(QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz')
+        QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz'
     shell:
         """cp {input} {output}"""
 
 rule clean_qc:
     input:
         expand(
-            str(QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz'),
+            QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz',
             sample=Samples.keys(), rp=Pairs)
     params:
-        cutadapt_fp = str(QC_FP/'01_cutadapt'),
-        trimmomatic_fp = str(QC_FP/'02_trimmomatic'),
-        komplexity_fp = str(QC_FP/'03_komplexity')
+        cutadapt_fp = QC_FP/'01_cutadapt',
+        trimmomatic_fp = QC_FP/'02_trimmomatic',
+        komplexity_fp = QC_FP/'03_komplexity'
     output:
         touch(".qc_cleaned")
     shell:

--- a/rules/reports/reports.smk
+++ b/rules/reports/reports.smk
@@ -11,16 +11,16 @@ rule preprocess_report:
     """Combines the information from multiple preprocessing steps"""
     input:
         trim_files = expand(
-            str(QC_FP/'log'/'trimmomatic'/'{sample}.out'),
+            QC_FP/'log'/'trimmomatic'/'{sample}.out',
             sample=sorted(Samples.keys())),
         decontam_files = expand(
-            str(QC_FP/'log'/'decontam'/'{sample}_1.txt'),
+            QC_FP/'log'/'decontam'/'{sample}_1.txt',
             sample=sorted(Samples.keys())),
         komplexity_files = expand(
-            str(QC_FP/'log'/'komplexity'/'{sample}.filtered_ids'),
+            QC_FP/'log'/'komplexity'/'{sample}.filtered_ids',
             sample=sorted(Samples.keys())),
     output:
-        str(QC_FP/'reports'/'preprocess_summary.tsv')
+        QC_FP/'reports'/'preprocess_summary.tsv'
     conda:
         "../../envs/reports.yml"
     script:
@@ -31,10 +31,10 @@ rule fastqc_report:
     """ make fastqc reports """
     input:
         files = expand(
-            str(QC_FP/'reports'/'{sample}_{rp}_fastqc/fastqc_data.txt'),
+            QC_FP/'reports'/'{sample}_{rp}_fastqc/fastqc_data.txt',
             sample=Samples.keys(),rp=Pairs)
     output:
-        str(QC_FP/'reports'/'fastqc_quality.tsv')
+        QC_FP/'reports'/'fastqc_quality.tsv'
     conda:
         "../../envs/reports.yml"
     script:
@@ -49,7 +49,7 @@ rule multiqc_report:
         MULTIQC_REPORT
     params:
         title = Cfg['qc'].get('report_title', 'QC report'),
-        outdir = str(QC_FP/'reports')
+        outdir = QC_FP/'reports'
     conda:
         "../../envs/reports.yml"
     script:

--- a/rules/targets/targets.smk
+++ b/rules/targets/targets.smk
@@ -5,31 +5,31 @@
 # ---- Quality control
 # FastQC reports
 TARGET_FASTQC = expand(
-    str(QC_FP/'reports'/'{sample}_{rp}_fastqc'/'fastqc_data.txt'),
+    QC_FP/'reports'/'{sample}_{rp}_fastqc'/'fastqc_data.txt',
     sample=Samples.keys(), rp=Pairs)
 
 # Quality-control reads
 TARGET_CLEAN = expand(
-    str(QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz'),
+    QC_FP/'cleaned'/'{sample}_{rp}.fastq.gz',
     sample = Samples.keys(), rp = Pairs)
 
 TARGET_QC = TARGET_CLEAN + TARGET_FASTQC
 
 # Remove host reads
 TARGET_DECONTAM = expand(
-    str(QC_FP/'decontam'/'{sample}_{rp}.fastq.gz'),
+    QC_FP/'decontam'/'{sample}_{rp}.fastq.gz',
     sample = Samples.keys(), rp = Pairs)
 
 
 # ---- Classification
 # Classify all reads
-TARGET_CLASSIFY = [str(CLASSIFY_FP/'kraken'/'all_samples.tsv')]
+TARGET_CLASSIFY = [CLASSIFY_FP/'kraken'/'all_samples.tsv']
 
 
 # ---- Assembly
 # Assemble contigs
 TARGET_ASSEMBLY = expand(
-    str(ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa'),
+    ASSEMBLY_FP/'contigs'/'{sample}-contigs.fa',
     sample = Samples.keys())
 
 
@@ -37,13 +37,13 @@ TARGET_ASSEMBLY = expand(
 # Map reads to target genomes
 TARGET_MAPPING = [
     expand(
-        str(MAPPING_FP/"{genome}"/"{sample}.bam.bai"),
+        MAPPING_FP/"{genome}"/"{sample}.bam.bai",
         genome=GenomeSegments.keys(), sample=Samples.keys()),
     expand(
-        str(MAPPING_FP/"{genome}"/"{sample}.raw.bcf"),
+        MAPPING_FP/"{genome}"/"{sample}.raw.bcf",
         genome=GenomeSegments.keys(), sample=Samples.keys()),
     expand(
-        str(MAPPING_FP/"{genome}"/"coverage.csv"),
+        MAPPING_FP/"{genome}"/"coverage.csv",
         genome=GenomeSegments.keys())
 ]
 
@@ -51,18 +51,18 @@ TARGET_MAPPING = [
 # ---- Contig annotation
 # Annotate all contigs
 TARGET_ANNOTATE = expand(
-    str(ANNOTATION_FP/'summary'/'{sample}.tsv'),
+    ANNOTATION_FP/'summary'/'{sample}.tsv',
     sample=Samples.keys())
 
 
 # ---- Reports
 # MultiQC report
-MULTIQC_REPORT = str(QC_FP/'reports'/'multiqc_report.html')
+MULTIQC_REPORT = QC_FP/'reports'/'multiqc_report.html'
 
 TARGET_REPORT = [
-    str(QC_FP/'reports'/'preprocess_summary.tsv'),
-    str(QC_FP/'reports'/'fastqc_quality.tsv'),
-    str(ASSEMBLY_FP/'contigs_coverage.txt'),
+    QC_FP/'reports'/'preprocess_summary.tsv',
+    QC_FP/'reports'/'fastqc_quality.tsv',
+    ASSEMBLY_FP/'contigs_coverage.txt',
     MULTIQC_REPORT
 ]
 


### PR DESCRIPTION
* [x] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [x] If this adds a new output file, I have added a check to tests/targets.txt
* [x] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [x] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

Remove `str` statements from around Path objects (new as of Python 3.9)