### PR TITLE
Core and all tests separated plus docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: run tests
           command: |
             TAG=$(git describe --tag)
-            bash tests/run_tests.bash -e sunbeam${TAG:1}
+            bash tests/run_tests.bash -e sunbeam${TAG:1} -t all
           no_output_timeout: 40m
 
       - save_cache:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,5 +59,6 @@ sequencing experiments. *Microbiome* 7:46 (2019)
    extensions.rst
    install.rst
    manage-version.rst
+   run_tests.rst
    citation.rst
 

--- a/docs/run_tests.rst
+++ b/docs/run_tests.rst
@@ -1,0 +1,48 @@
+.. _run_tests:
+
+==============
+run_tests.bash
+==============
+
+.. contents::
+   :depth: 2
+
+Overview
+========
+
+This script manages the testing of sunbeam. It can be used to run a set of 
+core tests that will verify a successful installation, run specific tests, or 
+run all tests. The default behavior is to run the core set. It also gives the 
+options to use a permanent directory for outputs (instead of a temporary one) 
+or to use a pre-existing environment (instead of creating a temporary one).
+
+Options
+=======
+
+All available options for the command line, used with ``tests/run_tests.sh [options]``.
+
+-d [arg]
+++++++++
+
+Use [DIR] rather than a temporary directory (remains after tests finish).
+
+-e [arg]
+++++++++
+
+Use a pre-existing Conda [ENV] rather than creating one (remains after tests finish).
+
+-t [arg]
+++++++++
+
+Run a specific [TEST] from tests/test_suite.bash only or run [all] (default: runs core tests only).
+
+-v
++++
+
+Show subcommand output.
+
+-h
++++
+
+Display help message.
+

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -57,7 +57,7 @@ while getopts "d:e:t:vh" opt; do
 	    echo "Run the Sunbeam test suite."
 	    echo "  -d DIR       Use DIR rather than a temporary directory (remains after tests finish)"
 	    echo "  -e ENV_NAME  Use a pre-existing Conda environment rather than creating one (remains after tests finish)"
-	    echo "  -t TEST      Run a specific test from tests/test_suite.bash only"
+	    echo "  -t TEST      Run a specific test from tests/test_suite.bash only or run all (default: runs core tests)"
 	    echo "  -v           Show command output while running"
 	    echo "  -h           Display this message and exit"
 	    exit 1
@@ -232,7 +232,16 @@ function build_test_data {
 
 function run_test_suite {
     for testcase in $(declare -f | grep -o "^test[a-zA-Z_]*") ; do
-	capture_output ${testcase}
+	    capture_output ${testcase}
+    done
+}
+
+function run_core_test_suite {
+    declare -a core_tests=("test_all" "test_mapping" "test_assembly_failures")
+
+    for testcase in "${core_tests[@]}"
+    do
+        capture_output ${testcase}
     done
 }
 
@@ -245,9 +254,13 @@ source tests/test_suite.bash
 
 # Run single test, if specified, or all detected tests otherwise
 if [ ! -z ${RUN_TEST+x} ]; then
-    capture_output ${RUN_TEST}
+    if [ $RUN_TEST  = "all" ]; then
+        run_test_suite
+    else
+        capture_output ${RUN_TEST}
+    fi
 else
-    run_test_suite
+    run_core_test_suite
 fi
 
 


### PR DESCRIPTION
* [ ] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
