### PR TITLE
Fix sunbeam config modify not working for extensions

### DIFF
--- a/sunbeamlib/config.py
+++ b/sunbeamlib/config.py
@@ -123,10 +123,10 @@ def update(config_str, new, strict=False):
     if strict:
         config = _update_dict_strict(config, new)
     else:
-        config = _update_dict(config, new)
         sbx_config = ruamel.yaml.round_trip_load(extension_config())
         if sbx_config:
             config = _update_dict(config, sbx_config)
+        config = _update_dict(config, new)
     return config
 
 

--- a/sunbeamlib/scripts/_config.py
+++ b/sunbeamlib/scripts/_config.py
@@ -71,7 +71,7 @@ def main(argv):
         "1. To apply a set of defaults to an existing config file in place:\n"
         "    $ sunbeam config modify -i -f defaults.yml my_config.yml\n"
         "2. To change a single key:value pair in the 'mapping' section:\n"
-        "    $ sunbeam config modify -i -s 'mapping: {keep_unaligned: True}'"
+        "    $ sunbeam config modify -i -s 'mapping: {keep_unaligned: True}' my_config.yml"
     )
     modify_command = subcommands.add_parser(
         "modify",


### PR DESCRIPTION
* [ ] I have run `bash tests/test.sh` on a local deployment and the tests passed successfully
* [ ] If this adds a new output file, I have added a check to tests/targets.txt
* [ ] If this fixes a bug, I have added an appropriate test to tests/test.sh
* [ ] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`
