### PR TITLE
Improve benchmarking reports

### DIFF
--- a/.github/workflows/test_tar_release.yml
+++ b/.github/workflows/test_tar_release.yml
@@ -1,4 +1,4 @@
-name: Test Tarball on Release
+name: Test Tar
 
 on:
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@ configs/config*.yml
 \#*
 output
 __pycache__
-.tests/data/hosts/*.fasta.*
-.tests/data/raw/*.fasta.*
+tests/data/hosts/*.fasta.*
+tests/data/raw/*.fasta.*
 tests/sunbeam_output
 tests/bacteria
 tests/local
@@ -19,3 +19,5 @@ docs/_build
 extensions/*
 !extensions/.placeholder
 build
+.vscode/
+projects/

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -71,13 +71,15 @@ Usage examples:
 1. To run all targets (not including extensions):
    ``sunbeam run --profile /path/to/project/``
 2. To specify multiple targets:
+   ``sunbeam run --profile /path/to/project/ all_decontam all_assembly all_annotation``
+3. The equivalent of 2, using the deprecated ``--target_list`` option:
    ``sunbeam run --profile /path/to/project/ --target_list all_decontam all_assembly all_annotation``
 
 .. code-block:: shell
 
     -h/--help: Display help.
     -s/--sunbeam_dir: Path to sunbeam installation.
-    --target_list: A list of targets to run successively.
+    --target_list: A list of targets to run successively. (DEPRECATED)
     <snakemake options>: You can pass further arguments to Snakemake after ``--``, e.g: ``$ sunbeam run -- --cores 12``. See http://snakemake.readthedocs.io for more information.
 
 .. tip::

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - snakemake
+  - snakemake >=7.32.0
   - git # Ensure sunbeam extend works even with tar installation of main pipeline
   - python =3.12.0

--- a/src/sunbeamlib/post.py
+++ b/src/sunbeamlib/post.py
@@ -6,7 +6,9 @@ from snakemake.common import Rules
 from typing import Dict
 
 
-def compile_benchmarks(benchmark_fp: str, Cfg: Dict[str, Dict | str], rules: Rules) -> None:
+def compile_benchmarks(
+    benchmark_fp: str, Cfg: Dict[str, Dict | str], rules: Rules
+) -> None:
     """Aggregate all the benchmark files into one and put it in stats_fp"""
     stats_fp = Path(Cfg["all"]["root"]) / "stats"
     benchmarks = []
@@ -25,7 +27,7 @@ def compile_benchmarks(benchmark_fp: str, Cfg: Dict[str, Dict | str], rules: Rul
 
     if not os.path.exists(stats_fp):
         os.makedirs(stats_fp)
-    
+
     dt = str(int(datetime.datetime.now().timestamp() * 1000))
     stats_file = os.path.join(stats_fp, f"{dt}_benchmarks.tsv")
 
@@ -37,11 +39,13 @@ def compile_benchmarks(benchmark_fp: str, Cfg: Dict[str, Dict | str], rules: Rul
                 reader = csv.reader(g, delimiter="\t")
                 next(reader)  # Headers line
                 writer.writerow([fp[:-4]] + next(reader))
-    
+
     compile_file_stats(stats_fp, Cfg, dt, rules)
 
 
-def compile_file_stats(stats_fp: str, Cfg: Dict[str, Dict | str], dt: str, rules: Rules) -> None:
+def compile_file_stats(
+    stats_fp: str, Cfg: Dict[str, Dict | str], dt: str, rules: Rules
+) -> None:
     """Collect data on all inputs and outputs (as long as they still exist at this point) as well as dbs"""
     file_stats = {}
     output_fp = Path(Cfg["all"]["root"]) / Cfg["all"]["output_fp"]
@@ -70,7 +74,7 @@ def compile_file_stats(stats_fp: str, Cfg: Dict[str, Dict | str], dt: str, rules
                         param_fps.add(Path(p))
                     except TypeError:
                         continue
-    
+
     for fp in param_fps:
         if fp.exists():
             if fp.is_file():

--- a/src/sunbeamlib/post.py
+++ b/src/sunbeamlib/post.py
@@ -33,3 +33,20 @@ def compile_benchmarks(benchmark_fp: str, stats_fp: str) -> None:
                 reader = csv.reader(g, delimiter="\t")
                 next(reader)  # Headers line
                 writer.writerow([fp[:-4]] + next(reader))
+
+import sys
+def update_benchmark(func):
+    # added arguments inside the inner1,
+    # if function takes any arguments,
+    # can be added like this.
+    def inner1(*args, **kwargs):
+ 
+        # storing time before function execution
+        sys.stderr.write("B")
+         
+        func(*args, **kwargs)
+ 
+        # storing time after function execution
+        sys.stderr.write("A")
+ 
+    return inner1

--- a/src/sunbeamlib/post.py
+++ b/src/sunbeamlib/post.py
@@ -1,10 +1,13 @@
 import csv
 import datetime
 import os
+from pathlib import Path
+from typing import Dict
 
 
-def compile_benchmarks(benchmark_fp: str, stats_fp: str) -> None:
+def compile_benchmarks(benchmark_fp: str, Cfg: Dict[str, Dict | str]) -> None:
     """Aggregate all the benchmark files into one and put it in stats_fp"""
+    stats_fp = Path(Cfg["all"]["root"]) / "stats"
     benchmarks = []
     try:
         benchmarks = os.listdir(benchmark_fp)
@@ -21,10 +24,10 @@ def compile_benchmarks(benchmark_fp: str, stats_fp: str) -> None:
 
     if not os.path.exists(stats_fp):
         os.makedirs(stats_fp)
-    stats_file = os.path.join(
-        stats_fp,
-        f"{str(int(datetime.datetime.now().timestamp() * 1000))}_benchmarks.tsv",
-    )
+    
+    dt = str(int(datetime.datetime.now().timestamp() * 1000))
+    stats_file = os.path.join(stats_fp, f"{dt}_benchmarks.tsv")
+
     with open(stats_file, "w") as f:
         writer = csv.writer(f, delimiter="\t")
         writer.writerow(headers)
@@ -33,20 +36,44 @@ def compile_benchmarks(benchmark_fp: str, stats_fp: str) -> None:
                 reader = csv.reader(g, delimiter="\t")
                 next(reader)  # Headers line
                 writer.writerow([fp[:-4]] + next(reader))
+    
+    compile_file_stats(stats_fp, Cfg, dt)
 
-import sys
-def update_benchmark(func):
-    # added arguments inside the inner1,
-    # if function takes any arguments,
-    # can be added like this.
-    def inner1(*args, **kwargs):
- 
-        # storing time before function execution
-        sys.stderr.write("B")
-         
-        func(*args, **kwargs)
- 
-        # storing time after function execution
-        sys.stderr.write("A")
- 
-    return inner1
+
+def compile_file_stats(stats_fp: str, Cfg: Dict[str, Dict | str], dt: str) -> None:
+    """Collect data on all inputs and outputs (as long as they still exist at this point) as well as dbs"""
+    file_stats = {}
+    output_fp = Path(Cfg["all"]["root"]) / Cfg["all"]["output_fp"]
+
+    stats_file = os.path.join(stats_fp, f"{dt}_file_stats.tsv")
+
+    # Collect info on all files in output_fp
+    for root, dirs, files in os.walk(output_fp):
+        for file in files:
+            fp = Path(root) / file
+            file_stats[fp] = fp.stat().st_size
+
+    # Collect info on all dbs in Cfg
+    for section, values in Cfg.items():
+        if section == "all":
+            continue
+        print(values)
+        for v in values:
+            try:
+                vp = Path(v)
+            except TypeError:
+                continue
+            if vp.exists():
+                if vp.is_file():
+                    file_stats[vp] = vp.stat().st_size
+                elif vp.is_dir():
+                    for file in os.listdir(vp):
+                        fp = vp / file
+                        file_stats[fp] = fp.stat().st_size
+
+    # Write to file
+    with open(stats_file, "w") as f:
+        writer = csv.writer(f, delimiter="\t")
+        writer.writerow(["file", "size"])
+        for fp, size in file_stats.items():
+            writer.writerow([fp, size])

--- a/src/sunbeamlib/post.py
+++ b/src/sunbeamlib/post.py
@@ -2,10 +2,11 @@ import csv
 import datetime
 import os
 from pathlib import Path
+from snakemake.common import Rules
 from typing import Dict
 
 
-def compile_benchmarks(benchmark_fp: str, Cfg: Dict[str, Dict | str]) -> None:
+def compile_benchmarks(benchmark_fp: str, Cfg: Dict[str, Dict | str], rules: Rules) -> None:
     """Aggregate all the benchmark files into one and put it in stats_fp"""
     stats_fp = Path(Cfg["all"]["root"]) / "stats"
     benchmarks = []
@@ -37,15 +38,48 @@ def compile_benchmarks(benchmark_fp: str, Cfg: Dict[str, Dict | str]) -> None:
                 next(reader)  # Headers line
                 writer.writerow([fp[:-4]] + next(reader))
     
-    compile_file_stats(stats_fp, Cfg, dt)
+    compile_file_stats(stats_fp, Cfg, dt, rules)
 
 
-def compile_file_stats(stats_fp: str, Cfg: Dict[str, Dict | str], dt: str) -> None:
+def compile_file_stats(stats_fp: str, Cfg: Dict[str, Dict | str], dt: str, rules: Rules) -> None:
     """Collect data on all inputs and outputs (as long as they still exist at this point) as well as dbs"""
     file_stats = {}
     output_fp = Path(Cfg["all"]["root"]) / Cfg["all"]["output_fp"]
 
     stats_file = os.path.join(stats_fp, f"{dt}_file_stats.tsv")
+
+    # Collect info on all files in params
+    param_fps = set()
+    for n, r in rules._rules.items():
+        if r.params:
+            for p in r.params:
+                if isinstance(p, dict):
+                    for k, v in p.items():
+                        try:
+                            param_fps.add(Path(v))
+                        except TypeError:
+                            continue
+                elif isinstance(p, list):
+                    for i in p:
+                        try:
+                            param_fps.add(Path(i))
+                        except TypeError:
+                            continue
+                else:
+                    try:
+                        param_fps.add(Path(p))
+                    except TypeError:
+                        continue
+    
+    for fp in param_fps:
+        if fp.exists():
+            if fp.is_file():
+                file_stats[fp] = fp.stat().st_size
+            elif fp.is_dir():
+                for file in os.listdir(fp):
+                    nfp = fp / file
+                    if nfp.exists() and nfp.is_file():
+                        file_stats[nfp] = nfp.stat().st_size
 
     # Collect info on all files in output_fp
     for root, dirs, files in os.walk(output_fp):
@@ -57,8 +91,7 @@ def compile_file_stats(stats_fp: str, Cfg: Dict[str, Dict | str], dt: str) -> No
     for section, values in Cfg.items():
         if section == "all":
             continue
-        print(values)
-        for v in values:
+        for k, v in values.items():
             try:
                 vp = Path(v)
             except TypeError:

--- a/src/sunbeamlib/script_run.py
+++ b/src/sunbeamlib/script_run.py
@@ -33,9 +33,6 @@ def main(argv=sys.argv):
         action="store_true",
         help="Use mamba instead of conda to manage environments",
     )
-    parser.add_argument(
-        "--target_list", nargs="+", default=[], help="List of sunbeam targets"
-    )
 
     # The remaining args (after --) are passed to Snakemake
     args, remaining = parser.parse_known_args(argv)
@@ -51,32 +48,19 @@ def main(argv=sys.argv):
 
     conda_cmd = "conda" if not args.mamba else "mamba"
 
-    cmds = list()
-    if args.target_list == []:
-        args.target_list = [""]
+    snakemake_args = [
+        "snakemake",
+        "--snakefile",
+        str(snakefile),
+        "--conda-prefix",
+        str(conda_prefix),
+        "--conda-frontend",
+        conda_cmd,
+    ] + remaining + [
+        "all_post"
+    ]
+    print("Running: " + " ".join(snakemake_args))
 
-    for target in args.target_list:
-        if target:
-            print(f"Running sunbeam on target: {target}")
+    cmd = subprocess.run(snakemake_args)
 
-        # Including target when it's en empty string breaks stuff so the extra
-        # list comp avoids that
-        snakemake_args = [
-            arg
-            for arg in [
-                "snakemake",
-                "--snakefile",
-                str(snakefile),
-                "--conda-prefix",
-                str(conda_prefix),
-                "--conda-frontend",
-                conda_cmd,
-                target,
-            ]
-            if arg
-        ] + remaining
-        print("Running: " + " ".join(snakemake_args))
-
-        cmds.append(subprocess.run(snakemake_args))
-
-    sys.exit(cmds[0].returncode)
+    sys.exit(cmd.returncode)

--- a/src/sunbeamlib/script_run.py
+++ b/src/sunbeamlib/script_run.py
@@ -54,6 +54,12 @@ def main(argv=sys.argv):
 
     conda_cmd = "conda" if not args.mamba else "mamba"
 
+    if args.target_list:
+        sys.stderr.write(
+            "Warning: passing targets to '--target_list' is deprecated. "
+            "Please use 'sunbeam run <opts> target1 target2 target3' instead.\n"
+        )
+
     snakemake_args = (
         [
             "snakemake",

--- a/src/sunbeamlib/script_run.py
+++ b/src/sunbeamlib/script_run.py
@@ -34,7 +34,10 @@ def main(argv=sys.argv):
         help="Use mamba instead of conda to manage environments",
     )
     parser.add_argument(
-        "--target_list", nargs="+", default=[], help="List of sunbeam targets (DEPRECATED)"
+        "--target_list",
+        nargs="+",
+        default=[],
+        help="List of sunbeam targets (DEPRECATED)",
     )
 
     # The remaining args (after --) are passed to Snakemake
@@ -51,15 +54,19 @@ def main(argv=sys.argv):
 
     conda_cmd = "conda" if not args.mamba else "mamba"
 
-    snakemake_args = [
-        "snakemake",
-        "--snakefile",
-        str(snakefile),
-        "--conda-prefix",
-        str(conda_prefix),
-        "--conda-frontend",
-        conda_cmd,
-    ] + remaining + args.target_list
+    snakemake_args = (
+        [
+            "snakemake",
+            "--snakefile",
+            str(snakefile),
+            "--conda-prefix",
+            str(conda_prefix),
+            "--conda-frontend",
+            conda_cmd,
+        ]
+        + remaining
+        + args.target_list
+    )
     print("Running: " + " ".join(snakemake_args))
 
     cmd = subprocess.run(snakemake_args)

--- a/src/sunbeamlib/script_run.py
+++ b/src/sunbeamlib/script_run.py
@@ -33,6 +33,9 @@ def main(argv=sys.argv):
         action="store_true",
         help="Use mamba instead of conda to manage environments",
     )
+    parser.add_argument(
+        "--target_list", nargs="+", default=[], help="List of sunbeam targets (DEPRECATED)"
+    )
 
     # The remaining args (after --) are passed to Snakemake
     args, remaining = parser.parse_known_args(argv)
@@ -56,7 +59,7 @@ def main(argv=sys.argv):
         str(conda_prefix),
         "--conda-frontend",
         conda_cmd,
-    ] + remaining
+    ] + remaining + args.target_list
     print("Running: " + " ".join(snakemake_args))
 
     cmd = subprocess.run(snakemake_args)

--- a/src/sunbeamlib/script_run.py
+++ b/src/sunbeamlib/script_run.py
@@ -56,9 +56,7 @@ def main(argv=sys.argv):
         str(conda_prefix),
         "--conda-frontend",
         conda_cmd,
-    ] + remaining + [
-        "all_post"
-    ]
+    ] + remaining
     print("Running: " + " ".join(snakemake_args))
 
     cmd = subprocess.run(snakemake_args)

--- a/src/sunbeamlib/slurm_profile.yaml
+++ b/src/sunbeamlib/slurm_profile.yaml
@@ -70,8 +70,8 @@ set-resources:
   - remove_low_complexity:runtime=120
   - align_to_host:mem_mb=16000
   - align_to_host:runtime=240
-  - filter_unmapped_reads:mem_mb=24000
-  - filter_unmapped_reads:runtime=240
+  - filter_reads:mem_mb=24000
+  - filter_reads:runtime=240
   - megahit_paired:mem_mb=20000
   - megahit_paired:runtime=720
   - final_filter:mem_mb=4000

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -132,42 +132,42 @@ for sbx_path, wildcards in sbxs:
 rule all:
     input:
         TARGET_ALL,
+    localrule: True
 
 
 rule samples:
     message:
         "Samples to be processed:"
+    localrule: True
     run:
         [print(sample) for sample in sorted(list(Samples.keys()))]
 
 
-rules_dict = rules._rules
+rules_dict = {n: r for n, r in rules._rules.items()}
 for n, r in rules_dict.items():
-    print(n)
+    wildcard_str = ""
+    if r.rule._wildcard_names:
+        wildcard_str = "_{" + "}_{".join(r.rule._wildcard_names) + "}"
     try:
         rule:
-            name: n + "_benchmark"
+            name: n + "_post"
             input:
                 r.output,
                 r.benchmark,
+            output:
+                BENCHMARK_FP / "post" / f".{n}{wildcard_str}.done"
+            localrule: True
             run:
                 print(n)
     except TypeError:
         pass
 
-rule:
-    name: 
-        str(rules.sample_intake.rule)
+
+rule all_post:
     input:
-        rules.sample_intake.output,
-        #rules.sample_intake.benchmark,
-    output:
-        "TEST.txt"
-    shell:
-        "echo 'yea'"
-
-
-sys.stderr.write(str(rules.sample_intake.rule))
+        [BENCHMARK_FP / "post" / f".{n}.done" for n, r in rules_dict.items()]
+    localrule: True
+    
 
 
 onstart:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -132,15 +132,18 @@ for sbx_path, wildcards in sbxs:
 rule all:
     input:
         TARGET_ALL,
-    localrule: True
 
 
 rule samples:
     message:
         "Samples to be processed:"
-    localrule: True
     run:
         [print(sample) for sample in sorted(list(Samples.keys()))]
+
+
+localrules:
+    all,
+    samples,
 
 
 onstart:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -141,6 +141,35 @@ rule samples:
         [print(sample) for sample in sorted(list(Samples.keys()))]
 
 
+rules_dict = rules._rules
+for n, r in rules_dict.items():
+    print(n)
+    try:
+        rule:
+            name: n + "_benchmark"
+            input:
+                r.output,
+                r.benchmark,
+            run:
+                print(n)
+    except TypeError:
+        pass
+
+rule:
+    name: 
+        str(rules.sample_intake.rule)
+    input:
+        rules.sample_intake.output,
+        #rules.sample_intake.benchmark,
+    output:
+        "TEST.txt"
+    shell:
+        "echo 'yea'"
+
+
+sys.stderr.write(str(rules.sample_intake.rule))
+
+
 onstart:
     try:
         shutil.rmtree(BENCHMARK_FP)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -143,33 +143,6 @@ rule samples:
         [print(sample) for sample in sorted(list(Samples.keys()))]
 
 
-rules_dict = {n: r for n, r in rules._rules.items()}
-for n, r in rules_dict.items():
-    wildcard_str = ""
-    if r.rule._wildcard_names:
-        wildcard_str = "_{" + "}_{".join(r.rule._wildcard_names) + "}"
-    try:
-        rule:
-            name: n + "_post"
-            input:
-                r.output,
-                r.benchmark,
-            output:
-                BENCHMARK_FP / "post" / f".{n}{wildcard_str}.done"
-            localrule: True
-            run:
-                print(n)
-    except TypeError:
-        pass
-
-
-rule all_post:
-    input:
-        [BENCHMARK_FP / "post" / f".{n}.done" for n, r in rules_dict.items()]
-    localrule: True
-    
-
-
 onstart:
     try:
         shutil.rmtree(BENCHMARK_FP)
@@ -180,9 +153,9 @@ onstart:
 
 onsuccess:
     print("Sunbeam finished!")
-    compile_benchmarks(BENCHMARK_FP, Cfg["all"]["root"] / "stats")
+    compile_benchmarks(BENCHMARK_FP, Cfg)
 
 
 onerror:
     print("Sunbeam failed with error.")
-    compile_benchmarks(BENCHMARK_FP, Cfg["all"]["root"] / "stats")
+    compile_benchmarks(BENCHMARK_FP, Cfg)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -153,9 +153,9 @@ onstart:
 
 onsuccess:
     print("Sunbeam finished!")
-    compile_benchmarks(BENCHMARK_FP, Cfg)
+    compile_benchmarks(BENCHMARK_FP, Cfg, rules)
 
 
 onerror:
     print("Sunbeam failed with error.")
-    compile_benchmarks(BENCHMARK_FP, Cfg)
+    compile_benchmarks(BENCHMARK_FP, Cfg, rules)


### PR DESCRIPTION
Add input file sizes to benchmarking data collected
Deprecate --target_list option of sunbeam run
Fix config for filter_reads rule

* [x] I have run `pytest .tests/` on a local deployment and the tests passed successfully
* [x] If this adds a new output file, I have added a check to `.tests/targets.txt`
* [x] If this fixes a bug, I have added or modified an appropriate test
* [x] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

If this is for a release:
* [ ] I have updated documentation
* [ ] I have updated all conda pin files (`snakedeploy pin-conda-envs workflow/envs/*.yml`)
* [ ] I have updated the hardcoded version at the top of `install.sh` to match what this release's version will be
* [ ] I have created a release archive that will be attached to this release (`bash dev_scripts/generate_archive.sh`)