### PR TITLE
Use hack to create slurm_extra resource within each rule

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,8 +49,7 @@ jobs:
               shell: bash
               run: |
                 cd $GITHUB_WORKSPACE
-                ls -l .
-                ls -l .snakemake/slurm_logs/
+                ls -l . | grep "slurm_test_"
     
     test-apptainer:
         name: Apptainer Test

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,6 +49,7 @@ jobs:
               shell: bash
               run: |
                 cd $GITHUB_WORKSPACE
+                ls -l .
                 ls -l .snakemake/slurm_logs/
     
     test-apptainer:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,7 +49,7 @@ jobs:
               shell: bash
               run: |
                 cd $GITHUB_WORKSPACE
-                ls -l slurm_*
+                ls -l .snakemake/
     
     test-apptainer:
         name: Apptainer Test

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,7 +49,7 @@ jobs:
               shell: bash
               run: |
                 cd $GITHUB_WORKSPACE
-                ls -l .snakemake/
+                ls -l .snakemake/slurm_logs/
     
     test-apptainer:
         name: Apptainer Test

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,6 +44,12 @@ jobs:
                 sunbeam init --data_fp tests/data/reads/ --profile slurm projects/test/
     
                 sunbeam run --default-resources slurm_account=runner --profile projects/test/ test
+
+            - name: Check output
+              shell: bash
+              run: |
+                cd $GITHUB_WORKSPACE
+                ls -l slurm_*
     
     test-apptainer:
         name: Apptainer Test

--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,5 @@ dependencies:
   - snakemake =8
   - git # Ensure sunbeam extend works even with tar installation of main pipeline
   - python =3.12.0
+  - pip:
+    - docker

--- a/install.sh
+++ b/install.sh
@@ -167,7 +167,7 @@ function install_environment () {
 function install_env_vars () {
     activate_sunbeam
     mkdir -p ${CONDA_PREFIX}/etc/conda/activate.d
-    echo -ne "#/bin/sh\nexport SUNBEAM_DIR=${__sunbeam_dir}\nexport SUNBEAM_VER=${__version_tag}\nexport SUNBEAM_MIN_MEM_MB=1000\nexport SUNBEAM_MIN_RUNTIME=60" > \
+    echo -ne "#/bin/sh\nexport SUNBEAM_DIR=${__sunbeam_dir}\nexport SUNBEAM_VER=${__version_tag}\nexport SUNBEAM_MIN_MEM_MB=8000\nexport SUNBEAM_MIN_RUNTIME=60" > \
 	 ${CONDA_PREFIX}/etc/conda/activate.d/env_vars.sh
     mkdir -p ${CONDA_PREFIX}/etc/conda/deactivate.d
     echo -ne "#/bin/sh\nunset SUNBEAM_DIR\nunset SUNBEAM_VER\nunset SUNBEAM_MIN_MEM_MB\nunset SUNBEAM_MIN_RUNTIME" > \

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 __conda_url=https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-__version_tag=$(if git describe --tags >/dev/null 2>&1 ; then git describe --tags; else echo v4.3.7; fi) # <--- Update this on each version release
+__version_tag=$(if git describe --tags >/dev/null 2>&1 ; then git describe --tags; else echo v4.4.0; fi) # <--- Update this on each version release
 __version_tag="${__version_tag:1}" # Remove the 'v' prefix
 
 read -r -d '' __usage <<-'EOF'

--- a/src/sunbeamlib/slurm_profile.yaml
+++ b/src/sunbeamlib/slurm_profile.yaml
@@ -23,9 +23,6 @@ default-resources:
   - mem_mb=8000
   - runtime=15
   - disk_mb=1000
-  # Passing the rule name to slurm_extra isn't working
-  # See https://github.com/sunbeam-labs/sunbeam/pull/454/commits/77d283e1a3ccab7e0701ffaa38f5cdb811a9e3d4 for temp fix
-  #- slurm_extra="--job-name={rule} --output=slurm_{rule}_%j.out"
 # set-threads: map rule names to threads
 set-threads:
   - diamond_reads=8

--- a/src/sunbeamlib/slurm_profile.yaml
+++ b/src/sunbeamlib/slurm_profile.yaml
@@ -23,7 +23,9 @@ default-resources:
   - mem_mb=8000
   - runtime=15
   - disk_mb=1000
-  - slurm_extra="--job-name={rule} --output=slurm_{rule}_%j.out"
+  # Passing the rule name to slurm_extra isn't working
+  # See https://github.com/sunbeam-labs/sunbeam/pull/454/commits/77d283e1a3ccab7e0701ffaa38f5cdb811a9e3d4 for temp fix
+  #- slurm_extra="--job-name={rule} --output=slurm_{rule}_%j.out"
 # set-threads: map rule names to threads
 set-threads:
   - diamond_reads=8

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -190,7 +190,7 @@ for rule_name in rules._rules:
             lambda wc, rule_name=rule_name: f"--output=slurm_{rule_name}_{'_'.join(wc)}_%j"
         )
     else:
-        rule_obj.resources["slurm_extra"] = "--output=slurm_{rule_name}_%j"
+        rule_obj.resources["slurm_extra"] = f"--output=slurm_{rule_name}_%j"
 
 
 onstart:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -27,8 +27,8 @@ from sunbeamlib.reports import *
 client = docker.from_env()
 image_name = f"ctbushman/sunbeam:v{__version__}"
 try:
-    client.images.get(image_name)
-except docker.errors.ImageNotFound:
+    client.images.get_registry_data(image_name)
+except docker.errors.NotFound:
     sys.stderr.write(
         f"WARNING: {image_name} not found on DockerHub, using latest tag instead.\n"
     )

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -182,8 +182,6 @@ localrules:
     samples,
 
 
-for rule in rules._rules:
-    getattr(rules, rule).rule.resources["slurm_extra"] = f"--output=slurm_{rule}_%j"
 
 
 onstart:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -187,7 +187,7 @@ for rule_name in rules._rules:
     wcs = rule_obj._wildcard_names
     if wcs:
         rule_obj.resources["slurm_extra"] = (
-            lambda wc, rule_name=rule_name, wcs=wcs: f"--output=slurm_{rule_name}_{'_'.join([getattr(wc , x) for x in wcs])}_%j"
+            lambda wc, rule_name=rule_name: f"--output=slurm_{rule_name}_{'_'.join(wc)}_%j"
         )
     else:
         rule_obj.resources["slurm_extra"] = "--output=slurm_{rule_name}_%j"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -186,7 +186,9 @@ for rule_name in rules._rules:
     rule_obj = getattr(rules, rule_name).rule
     wcs = rule_obj._wildcard_names
     if wcs:
-        rule_obj.resources["slurm_extra"] = lambda wc, rule_name=rule_name, wcs=wcs: f"--output=slurm_{rule_name}_{'_'.join([getattr(wc, x) for x in wcs])}_%j"
+        rule_obj.resources["slurm_extra"] = (
+            lambda wc, rule_name=rule_name, wcs=wcs: f"--output=slurm_{rule_name}_{'_'.join([getattr(wc , x) for x in wcs])}_%j"
+        )
     else:
         rule_obj.resources["slurm_extra"] = "--output=slurm_{rule_name}_%j"
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -28,10 +28,14 @@ client = docker.from_env()
 image_name = f"ctbushman/sunbeam:v{__version__}"
 try:
     client.images.get(image_name)
-    containerized: f"docker://ctbushman/sunbeam:v{__version__}"
 except docker.errors.ImageNotFound:
-    sys.stderr.write(f"WARNING: {image_name} not found on DockerHub, using latest tag instead.\n")
-    containerized: f"docker://ctbushman/sunbeam:latest"
+    sys.stderr.write(
+        f"WARNING: {image_name} not found on DockerHub, using latest tag instead.\n"
+    )
+    image_name = "ctbushman/sunbeam:latest"
+
+
+containerized: f"docker://{image_name}"
 
 
 # Disallow slashes in our sample names during Snakemake's wildcard evaluation.

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -182,8 +182,6 @@ localrules:
     samples,
 
 
-
-
 onstart:
     try:
         shutil.rmtree(BENCHMARK_FP)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -182,6 +182,11 @@ localrules:
     samples,
 
 
+for rule in rules._rules:
+    getattr(rules, rule).rule.resources["slurm_extra"] = f"--job-name={rule} --output=slurm_{rule}_%j"
+    print(getattr(rules, rule).rule.resources)
+
+
 onstart:
     try:
         shutil.rmtree(BENCHMARK_FP)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -183,8 +183,9 @@ localrules:
 
 
 for rule in rules._rules:
-    getattr(rules, rule).rule.resources["slurm_extra"] = f"--job-name={rule} --output=slurm_{rule}_%j"
-    print(getattr(rules, rule).rule.resources)
+    getattr(rules, rule).rule.resources[
+        "slurm_extra"
+    ] = f"--job-name={rule} --output=slurm_{rule}_%j"
 
 
 onstart:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -183,7 +183,15 @@ localrules:
 
 
 for rule in rules._rules:
-    slurm_extra = f"--job-name={rule} --output=slurm_{rule}_%j"
+    wcs = getattr(rules, rule).rule._wildcard_names
+    output = f"slurm_{rule}"
+    if wcs:
+        for wc in wcs:
+            output += f"_{{{wc}}}"
+    output += "_%j"
+    
+    slurm_extra = f"--output={output}"
+
     getattr(rules, rule).rule.resources["slurm_extra"] = slurm_extra
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -183,12 +183,7 @@ localrules:
 
 
 for rule in rules._rules:
-    wcs = getattr(rules, rule).rule._wildcard_names
-
-    if wcs:
-        getattr(rules, rule).rule.resources["slurm_extra"] = lambda wc: f"--output=slurm_{rule}_{'_'.join([wc.x for x in wcs])}_%j"
-    else:
-        getattr(rules, rule).rule.resources["slurm_extra"] = f"--output=slurm_{rule}_%j"
+    getattr(rules, rule).rule.resources["slurm_extra"] = f"--output=slurm_{rule}_%j"
 
 
 onstart:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -183,9 +183,8 @@ localrules:
 
 
 for rule in rules._rules:
-    getattr(rules, rule).rule.resources[
-        "slurm_extra"
-    ] = f"--job-name={rule} --output=slurm_{rule}_%j"
+    slurm_extra = f"--job-name={rule} --output=slurm_{rule}_%j"
+    getattr(rules, rule).rule.resources["slurm_extra"] = slurm_extra
 
 
 onstart:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -5,6 +5,7 @@
 # Created: 2016-04-28
 #
 import configparser
+import docker
 import os
 import re
 import shutil
@@ -23,8 +24,14 @@ from sunbeamlib.parse import read_seq_ids
 from sunbeamlib.post import *
 from sunbeamlib.reports import *
 
-
-containerized: f"docker://ctbushman/sunbeam:v{__version__}"
+client = docker.from_env()
+image_name = f"ctbushman/sunbeam:v{__version__}"
+try:
+    client.images.get(image_name)
+    containerized: f"docker://ctbushman/sunbeam:v{__version__}"
+except docker.errors.ImageNotFound:
+    sys.stderr.write(f"WARNING: {image_name} not found on DockerHub, using latest tag instead.\n")
+    containerized: f"docker://ctbushman/sunbeam:latest"
 
 
 # Disallow slashes in our sample names during Snakemake's wildcard evaluation.

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -184,15 +184,11 @@ localrules:
 
 for rule in rules._rules:
     wcs = getattr(rules, rule).rule._wildcard_names
-    output = f"slurm_{rule}"
-    if wcs:
-        for wc in wcs:
-            output += f"_{{{wc}}}"
-    output += "_%j"
-    
-    slurm_extra = f"--output={output}"
 
-    getattr(rules, rule).rule.resources["slurm_extra"] = slurm_extra
+    if wcs:
+        getattr(rules, rule).rule.resources["slurm_extra"] = lambda wc: f"--output=slurm_{rule}_{'_'.join([wc.x for x in wcs])}_%j"
+    else:
+        getattr(rules, rule).rule.resources["slurm_extra"] = f"--output=slurm_{rule}_%j"
 
 
 onstart:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -182,6 +182,15 @@ localrules:
     samples,
 
 
+for rule_name in rules._rules:
+    rule_obj = getattr(rules, rule_name).rule
+    wcs = rule_obj._wildcard_names
+    if wcs:
+        rule_obj.resources["slurm_extra"] = lambda wc, rule_name=rule_name, wcs=wcs: f"--output=slurm_{rule_name}_{'_'.join([getattr(wc, x) for x in wcs])}_%j"
+    else:
+        rule_obj.resources["slurm_extra"] = "--output=slurm_{rule_name}_%j"
+
+
 onstart:
     try:
         shutil.rmtree(BENCHMARK_FP)

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -18,13 +18,11 @@ rule all_qc:
 
 rule sample_intake:
     input:
-        lambda wc: Samples[wc.sample][wc.rp],
+        lambda wildcards: Samples[wildcards.sample][wildcards.rp],
     output:
         QC_FP / "00_samples" / "{sample}_{rp}.fastq.gz",
     log:
         LOG_FP / "sample_intake_{sample}_{rp}.log",
-    resources:
-        TEST=lambda wc: wc.sample == "test",
     script:
         "../scripts/sample_intake.py"
 

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -220,7 +220,7 @@ rule remove_low_complexity:
     benchmark:
         BENCHMARK_FP / "remove_low_complexity_{sample}_{rp}.tsv"
     resources:
-        mem_mb=lambda wc, input: max(MIN_MEM_MB, 2 * input.ids.size_mb),
+        mem_mb=lambda wc, input: max(MIN_MEM_MB, 2 * input.size_mb),
         runtime=lambda wc: max(MIN_RUNTIME, 120),
     conda:
         "../envs/reports.yml"

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -18,11 +18,13 @@ rule all_qc:
 
 rule sample_intake:
     input:
-        lambda wildcards: Samples[wildcards.sample][wildcards.rp],
+        lambda wc: Samples[wc.sample][wc.rp],
     output:
         QC_FP / "00_samples" / "{sample}_{rp}.fastq.gz",
     log:
         LOG_FP / "sample_intake_{sample}_{rp}.log",
+    resources:
+        TEST=lambda wc: wc.sample == "test",
     script:
         "../scripts/sample_intake.py"
 
@@ -219,6 +221,9 @@ rule remove_low_complexity:
         LOG_FP / "remove_low_complexity_{sample}_{rp}.log",
     benchmark:
         BENCHMARK_FP / "remove_low_complexity_{sample}_{rp}.tsv"
+    resources:
+        mem_mb=lambda wc, input: max(MIN_MEM_MB, 2 * input.ids.size_mb),
+        runtime=lambda wc: max(MIN_RUNTIME, 120),
     conda:
         "../envs/reports.yml"
     script:


### PR DESCRIPTION
* [x] I have run `pytest .tests/` on a local deployment and the tests passed successfully
* [x] If this adds a new output file, I have added a check to `.tests/targets.txt`
* [x] If this fixes a bug, I have added or modified an appropriate test
* [x] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

If this is for a release:
* [x] I have updated documentation
* [x] I have updated all conda pin files (`snakedeploy pin-conda-envs workflow/envs/*.yml`)
* [x] I have updated the hardcoded version at the top of `install.sh` to match what this release's version will be
* [x] I have created a release archive that will be attached to this release (`bash dev_scripts/generate_archive.sh`)