### PR TITLE
Include docker image reports (mostly package versions) in releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,3 @@
 If this is for a release:
 * [ ] I have updated documentation
 * [ ] I have updated the hardcoded version at the top of `install.sh` to match what this release's version will be
-* [ ] I have created a release archive that will be attached to this release (`bash dev_scripts/generate_archive.sh`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,5 @@
 
 If this is for a release:
 * [ ] I have updated documentation
-* [ ] I have updated all conda pin files (`snakedeploy pin-conda-envs workflow/envs/*.yml`)
 * [ ] I have updated the hardcoded version at the top of `install.sh` to match what this release's version will be
 * [ ] I have created a release archive that will be attached to this release (`bash dev_scripts/generate_archive.sh`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,52 @@ jobs:
         needs:
           - run-tests
           - check-version
+
+    generate-docker-reports-sunbeam:
+        runs-on: ubuntu-latest
+        container: sunbeamlabs/sunbeam:latest
+        needs: [push-dockerhub]
+
+        outputs:
+          snakemake_version: ${{ steps.sunbeam.outputs.snakemake_version }}
+          python_version: ${{ steps.sunbeam.outputs.python_version }}
+
+        steps:
+          - name: Generate sunbeam image report
+            id: sunbeam
+            run: |
+              echo "snakemake_version=$(snakemake --version)" >> "$GITHUB_OUTPUT"
+              echo "python_version=$(python --version)" >> "$GITHUB_OUTPUT"
+
+    generate-docker-reports-cutadapt:
+      runs-on: ubuntu-latest
+      container: sunbeamlabs/cutadapt:latest
+      needs: [push-dockerhub]
+
+      outputs:
+        cutadapt_version: ${{ steps.cutadapt.outputs.cutadapt_version }}
+
+      steps:
+        - name: Generate cutadapt image report
+          id: cutadapt
+          run: |
+            echo "cutadapt_version=$(cutadapt --version)" >> "$GITHUB_OUTPUT"
+
+    udpate-release-notes:
+        name: Update release notes
+        runs-on: ubuntu-latest
+        needs:
+          - generate-docker-reports-sunbeam
+          - generate-docker-reports-cutadapt
+        
+        steps:
+          - name: Add Image Reports to Release
+            uses: irongut/EditRelease@v1.2.0
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              id: ${{ github.event.release.id }}
+              body: "### sunbeamlabs/sunbeam:latest\nSnakemake: ${{ needs.generate-docker-reports-sunbeam.outputs.snakemake_version }}\nPython: ${{ needs.generate-docker-reports-sunbeam.outputs.python_version }}\n### sunbeamlabs/cutadapt:latest\nCutadapt: ${{ needs.generate-docker-reports-cutadapt.outputs.cutadapt_version }}"
+              replacebody: false
         
     run-integration-tests:
         uses: ./.github/workflows/integration-tests.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,16 +24,6 @@ jobs:
                 GIT_VERSION=$(bash install.sh -w)
                 echo "GIT_VERSION=$GIT_VERSION" >> $GITHUB_ENV
 
-          - name: Download and Extract
-            shell: bash
-            run: |
-                wget https://github.com/sunbeam-labs/sunbeam/releases/latest/download/sunbeam.tar.gz
-                mkdir tar_sunbeam
-                tar -zxf sunbeam.tar.gz -C tar_sunbeam
-                cd tar_sunbeam
-                TAR_VERSION=$(bash install.sh -w)
-                echo "TAR_VERSION=$TAR_VERSION" >> $GITHUB_ENV
-
           - id: get_version
             uses: battila7/get-version-action@v2
 
@@ -42,14 +32,34 @@ jobs:
                 RELEASE_VERSION=${{ steps.get_version.outputs.version-without-v }}
                 echo "Release version: ${RELEASE_VERSION}"
                 echo "GitHub version: ${{ env.GIT_VERSION }}"
-                echo "Tarball version: ${{ env.TAR_VERSION }}"
 
-                if [[ $RELEASE_VERSION == ${{ env.GIT_VERSION }} ]] && [[ ${{ env.GIT_VERSION }} == ${{ env.TAR_VERSION }} ]]; then
+                if [[ $RELEASE_VERSION == ${{ env.GIT_VERSION }} ]]; then
                     echo "Versions match, continuing..."
                 else
                     echo "Versions don't match, exiting..."
                     exit 1
                 fi
+
+    generate-tarball:
+        name: Generate Tarball and Add to Release
+        runs-on: ubuntu-latest
+        needs:
+          - run-tests
+          - check-version
+    
+        steps:
+          - name: Checkout Code
+            uses: actions/checkout@v4
+
+          - name: Generate Tarball
+            run: bash dev_scripts/generate_archive.sh
+
+          - name: Add Tarball to Release
+            uses: irongut/EditRelease@v1.2.0
+            with:
+              token: ${{ secrets.GITHUB_TOKEN }}
+              id: ${{ github.event.release.id }}
+              files: "sunbeam.tar.gz"
     
     test-tarball:
         name: Test Tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,15 +90,13 @@ jobs:
         needs: [push-dockerhub]
 
         outputs:
-          snakemake_version: ${{ steps.sunbeam.outputs.snakemake_version }}
-          python_version: ${{ steps.sunbeam.outputs.python_version }}
+          package_versions: ${{ steps.report.outputs.package_versions }}
 
         steps:
-          - name: Generate sunbeam image report
-            id: sunbeam
+          - name: Generate image report
+            id: report
             run: |
-              echo "snakemake_version=$(snakemake --version)" >> "$GITHUB_OUTPUT"
-              echo "python_version=$(python --version)" >> "$GITHUB_OUTPUT"
+              echo "package_versions=$(cat installed_packages.txt)" >> "$GITHUB_OUTPUT"
 
     generate-docker-reports-cutadapt:
       runs-on: ubuntu-latest
@@ -106,13 +104,55 @@ jobs:
       needs: [push-dockerhub]
 
       outputs:
-        cutadapt_version: ${{ steps.cutadapt.outputs.cutadapt_version }}
+        package_versions: ${{ steps.report.outputs.package_versions }}
 
       steps:
-        - name: Generate cutadapt image report
-          id: cutadapt
+        - name: Generate image report
+          id: report
           run: |
-            echo "cutadapt_version=$(cutadapt --version)" >> "$GITHUB_OUTPUT"
+            echo "package_versions=$(cat installed_packages.txt)" >> "$GITHUB_OUTPUT"
+
+    generate-docker-reports-komplexity:
+      runs-on: ubuntu-latest
+      container: sunbeamlabs/komplexity:latest
+      needs: [push-dockerhub]
+
+      outputs:
+        package_versions: ${{ steps.report.outputs.package_versions }}
+
+      steps:
+        - name: Generate image report
+          id: report
+          run: |
+            echo "package_versions=$(cat installed_packages.txt)" >> "$GITHUB_OUTPUT"
+    
+    generate-docker-reports-qc:
+      runs-on: ubuntu-latest
+      container: sunbeamlabs/qc:latest
+      needs: [push-dockerhub]
+
+      outputs:
+        package_versions: ${{ steps.report.outputs.package_versions }}
+
+      steps:
+        - name: Generate image report
+          id: report
+          run: |
+            echo "package_versions=$(cat installed_packages.txt)" >> "$GITHUB_OUTPUT"
+
+    generate-docker-reports-reports:
+      runs-on: ubuntu-latest
+      container: sunbeamlabs/reports:latest
+      needs: [push-dockerhub]
+
+      outputs:
+        package_versions: ${{ steps.report.outputs.package_versions }}
+
+      steps:
+        - name: Generate image report
+          id: report
+          run: |
+            echo "package_versions=$(cat installed_packages.txt)" >> "$GITHUB_OUTPUT"
 
     udpate-release-notes:
         name: Update release notes
@@ -120,6 +160,9 @@ jobs:
         needs:
           - generate-docker-reports-sunbeam
           - generate-docker-reports-cutadapt
+          - generate-docker-reports-komplexity
+          - generate-docker-reports-qc
+          - generate-docker-reports-reports
         
         steps:
           - name: Add Image Reports to Release
@@ -127,7 +170,7 @@ jobs:
             with:
               token: ${{ secrets.GITHUB_TOKEN }}
               id: ${{ github.event.release.id }}
-              body: "### sunbeamlabs/sunbeam:latest\nSnakemake: ${{ needs.generate-docker-reports-sunbeam.outputs.snakemake_version }}\nPython: ${{ needs.generate-docker-reports-sunbeam.outputs.python_version }}\n### sunbeamlabs/cutadapt:latest\nCutadapt: ${{ needs.generate-docker-reports-cutadapt.outputs.cutadapt_version }}"
+              body: "### sunbeamlabs/sunbeam\n${{ needs.generate-docker-reports-sunbeam.outputs.package_versions }}\n### sunbeamlabs/cutadapt\n${{ needs.generate-docker-reports-cutadapt.outputs.package_versions }}\n### sunbeamlabs/komplexity\n${{ needs.generate-docker-reports-komplexity.outputs.package_versions }}\n### sunbeamlabs/qc\n${{ needs.generate-docker-reports-qc.outputs.package_versions }}\n### sunbeamlabs/reports\n${{ needs.generate-docker-reports-reports.outputs.package_versions }}"
               replacebody: false
         
     run-integration-tests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN rm -r projects
 
 # "Activate" the environment
 SHELL ["conda", "run", "-n", "sunbeam", "/bin/bash", "-c"]
-#RUN bash /opt/conda/envs/sunbeam/etc/conda/activate.d/env_vars.sh
+
+RUN echo "Python: $(python --version)\nSnakemake: $(snakemake --version)\nConda: $(conda --version)" > installed_packages.txt
 
 # Run
 CMD "bash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY environment.yml install.sh MANIFEST.in pyproject.toml pytest.ini README.md 
 # Install sunbeam
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y git
+    apt-get install -y git vim
 RUN ./install.sh -e sunbeam -v
 
 ENV PATH="/opt/conda/envs/sunbeam/bin/:${PATH}"

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 __conda_url=https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-__version_tag=$(if git describe --tags >/dev/null 2>&1 ; then git describe --tags; else echo v4.5.1; fi) # <--- Update this on each version release
+__version_tag=$(if git describe --tags >/dev/null 2>&1 ; then git describe --tags; else echo v4.5.2; fi) # <--- Update this on each version release
 __version_tag="${__version_tag:1}" # Remove the 'v' prefix
 
 read -r -d '' __usage <<-'EOF'

--- a/slim.Dockerfile
+++ b/slim.Dockerfile
@@ -32,7 +32,8 @@ ENV SUNBEAM_MIN_RUNTIME="60"
 
 # "Activate" the environment
 SHELL ["conda", "run", "-n", "sunbeam", "/bin/bash", "-c"]
-#RUN bash /opt/conda/envs/sunbeam/etc/conda/activate.d/env_vars.sh
+
+RUN echo "Python: $(python --version)\nSnakemake: $(snakemake --version)\nConda: $(conda --version)" > installed_packages.txt
 
 # Run
 CMD "bash"

--- a/slim.Dockerfile
+++ b/slim.Dockerfile
@@ -21,7 +21,7 @@ COPY environment.yml install.sh MANIFEST.in pyproject.toml pytest.ini README.md 
 # Install sunbeam
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y git
+    apt-get install -y git vim
 RUN ./install.sh -e sunbeam -v
 
 ENV PATH="/opt/conda/envs/sunbeam/bin/:${PATH}"

--- a/workflow/envs/cutadapt.Dockerfile
+++ b/workflow/envs/cutadapt.Dockerfile
@@ -6,5 +6,7 @@ WORKDIR /home/cutadapt_env
 # Install environment
 RUN pip install cutadapt
 
+RUN echo "Python: $(python --version)\nCutadapt $(pip show cutadapt | grep 'Version: ')" > installed_packages.txt
+
 # Run
 CMD ["bash"]

--- a/workflow/envs/komplexity.Dockerfile
+++ b/workflow/envs/komplexity.Dockerfile
@@ -8,5 +8,7 @@ RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/eclarke/komplexity
 RUN cd komplexity && cargo install
 
+RUN echo "Rustc: $(rustc --version)\nKomplexity $(kz --version)" > installed_packages.txt
+
 # Run
 CMD ["bash"]

--- a/workflow/envs/qc.Dockerfile
+++ b/workflow/envs/qc.Dockerfile
@@ -13,5 +13,7 @@ ENV PATH="/opt/conda/envs/qc/bin/:${PATH}"
 # "Activate" the environment
 SHELL ["conda", "run", "--no-capture-output", "-n", "qc", "/bin/bash", "-c"]
 
+RUN echo "Python: $(python --version)\nConda: $(conda --version)\nBWA: $(bwa 2>&1 >/dev/null | grep 'Version: ')\nFastQC: $(fastqc --version)\nTrimmomatic: $(trimmomatic -version)" > installed_packages.txt
+
 # Run
 CMD "bash"

--- a/workflow/envs/reports.Dockerfile
+++ b/workflow/envs/reports.Dockerfile
@@ -6,5 +6,7 @@ WORKDIR /home/reports_env
 # Install environment
 RUN pip install numpy pandas
 
+RUN echo "Python: $(python --version)\nNumpy $(pip show numpy | grep 'Version: ')\nPandas $(pip show pandas | grep 'Version: ')" > installed_packages.txt
+
 # Run
 CMD ["bash"]


### PR DESCRIPTION
* [x] I have run `pytest .tests/` on a local deployment and the tests passed successfully
* [x] If this adds a new output file, I have added a check to `.tests/targets.txt`
* [x] If this fixes a bug, I have added or modified an appropriate test
* [x] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

If this is for a release:
* [x] I have updated documentation
* [x] I have updated all conda pin files (`snakedeploy pin-conda-envs workflow/envs/*.yml`)
* [x] I have updated the hardcoded version at the top of `install.sh` to match what this release's version will be
* [x] I have created a release archive that will be attached to this release (`bash dev_scripts/generate_archive.sh`)