### PR TITLE
Add universal extension path function to sunbeamlib

### DIFF
--- a/src/sunbeamlib/__init__.py
+++ b/src/sunbeamlib/__init__.py
@@ -42,6 +42,17 @@ def get_docker_str(repo: str, user: str = "sunbeamlabs") -> str:
     return f"docker://{user}/{repo}:{docker_tag}"
 
 
+def get_ext_path(ext_name: str) -> Path:
+    try:
+        ext_path = Path(os.environ["SUNBEAM_DIR"]) / "extensions" / ext_name
+    except KeyError:
+        raise ValueError("SUNBEAM_DIR not set in environment.")
+
+    if ext_path.exists():
+        return ext_path
+    raise ValueError(f"Extension {ext_name} not found in {os.environ['SUNBEAM_DIR']}.")
+
+
 def load_sample_list(
     samplelist_fp: Path, paired_end: bool = True
 ) -> Dict[str, Dict[str, str]]:


### PR DESCRIPTION
* [x] I have run `pytest .tests/` on a local deployment and the tests passed successfully
* [x] If this adds a new output file, I have added a check to `.tests/targets.txt`
* [x] If this fixes a bug, I have added or modified an appropriate test
* [x] If this adds or modifies a rule that uses FASTQ files, the input accepts gzipped FASTQ and outputs gzipped FASTQ, or marks uncompressed FASTQ output as `temp`

If this is for a release:
* [ ] I have updated documentation
* [ ] I have updated the hardcoded version at the top of `install.sh` to match what this release's version will be
* [ ] I have created a release archive that will be attached to this release (`bash dev_scripts/generate_archive.sh`)