### PR TITLE
Add AI diagnostic option for `sunbeam run`

### DIFF
--- a/tests/e2e/test_sunbeam_run.py
+++ b/tests/e2e/test_sunbeam_run.py
@@ -113,3 +113,27 @@ def test_sunbeam_run_with_target_after_exclude(tmp_path, DATA_DIR, capsys):
 
     assert "clean_qc" in captured.err
     assert "filter_reads" not in captured.err
+
+
+def test_sunbeam_run_ai_option(tmp_path, monkeypatch):
+    project_dir = tmp_path / "empty"
+    project_dir.mkdir()
+
+    called = {"flag": False}
+
+    def fake_analyze(log):
+        called["flag"] = True
+
+    monkeypatch.setattr("sunbeam.scripts.run.analyze_failure", fake_analyze)
+
+    with pytest.raises(SystemExit):
+        Run(
+            [
+                "--profile",
+                str(project_dir),
+                "--ai",
+                "-n",
+            ]
+        )
+
+    assert called["flag"]


### PR DESCRIPTION
## Summary
- optionally run OpenAI analysis when `sunbeam run` fails
- include helpful message if `openai` isn't installed
- test the new `--ai` flag

## Testing
- `black --check --line-length=88 .`
- `snakefmt --check sunbeam/workflow/Snakefile sunbeam/workflow/rules/*.smk`
- `pytest tests/unit tests/e2e/test_sunbeam_run.py::test_sunbeam_run_ai_option -vv`


------
https://chatgpt.com/codex/tasks/task_e_684b204d251c8323939eb91e01f4e71f