### PR TITLE
Fix integration test command

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,4 +55,4 @@ jobs:
               shell: bash
               run: |
                 sunbeam init --data_fp tests/data/reads/ --profile slurm test/
-                sunbeam run --default-resources slurm_account=runner --profile test/ test
+                sunbeam run --default-resources slurm_account=runner --profile test/ -- test


### PR DESCRIPTION
## Summary
- fix the integration test workflow's `sunbeam run` invocation

## Testing
- `pytest -q` *(fails: conda not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6b8fc12c83238e0a7bfc1892b553