### PR TITLE
Add initial AI workflow planner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dev = [
   "snakefmt==0.11.0",
   "pytest==8.4.0",
 ]
+ai = [
+  "langchain-openai>=0.3.23",
+  "langchain-community>=0.3.25",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/sunbeam-labs/sunbeam"
@@ -46,6 +50,7 @@ dev = [
 
 [project.scripts]
 sunbeam = "sunbeam.scripts.sunbeam:main"
+sunbeam-ai = "sunbeam.scripts.ai:main"
 
 [tool.setuptools.package-dir]
 sunbeam = "sunbeam"

--- a/sunbeam/ai/__init__.py
+++ b/sunbeam/ai/__init__.py
@@ -1,0 +1,5 @@
+"""AI-driven bioinformatics tools."""
+
+from .workflow import WorkflowPlanner
+
+__all__ = ["WorkflowPlanner"]

--- a/sunbeam/ai/workflow.py
+++ b/sunbeam/ai/workflow.py
@@ -1,0 +1,64 @@
+"""Utilities to generate and run AI-driven workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from langchain.prompts import ChatPromptTemplate
+from langchain.schema.runnable import Runnable
+from langchain.schema.output_parser import StrOutputParser
+
+try:
+    from langchain_openai import ChatOpenAI
+except ImportError:  # pragma: no cover - optional dependency
+    ChatOpenAI = None
+
+
+def default_llm():
+    if ChatOpenAI is None:
+        raise ImportError(
+            "langchain_openai is required for the default planner. Install"
+            " the 'ai' extra and set OPENAI_API_KEY"
+        )
+    return ChatOpenAI(temperature=0)
+
+
+@dataclass
+class WorkflowPlanner:
+    """Plan bioinformatics workflows using an LLM."""
+
+    llm: Runnable | None = None
+
+    def __post_init__(self):
+        if self.llm is None:
+            self.llm = default_llm()
+        self.chain = self._build_chain(self.llm)
+
+    @staticmethod
+    def _build_chain(llm: Runnable) -> Runnable:
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "You are an expert bioinformatics workflow planner. Given a description"
+                    " of the data, desired outputs, and allowed steps, produce a concise"
+                    " plan with shell commands to run each step.",
+                ),
+                (
+                    "user",
+                    "Input: {input_desc}\nDesired output: {output_desc}\nAllowed steps: {steps_hint}",
+                ),
+            ]
+        )
+        return prompt | llm | StrOutputParser()
+
+    def plan(self, input_desc: str, output_desc: str, steps_hint: str = "") -> str:
+        """Return a text plan for accomplishing the task."""
+
+        return self.chain.invoke(
+            {
+                "input_desc": input_desc,
+                "output_desc": output_desc,
+                "steps_hint": steps_hint,
+            }
+        )

--- a/sunbeam/scripts/ai.py
+++ b/sunbeam/scripts/ai.py
@@ -1,0 +1,29 @@
+"""CLI for AI-driven workflow planning."""
+
+import argparse
+import sys
+
+from sunbeam.ai import WorkflowPlanner
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a bioinformatics workflow plan using an LLM.",
+    )
+    parser.add_argument("input_description", help="Description of the input data")
+    parser.add_argument("output_description", help="Desired outputs")
+    parser.add_argument(
+        "--steps",
+        default="",
+        help="Comma separated list of allowed steps (optional)",
+    )
+
+    args = parser.parse_args(argv)
+
+    planner = WorkflowPlanner()
+    plan = planner.plan(args.input_description, args.output_description, args.steps)
+    sys.stdout.write(plan + "\n")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main(sys.argv[1:])

--- a/tests/unit/test_ai.py
+++ b/tests/unit/test_ai.py
@@ -1,0 +1,9 @@
+from sunbeam.ai.workflow import WorkflowPlanner
+from langchain_community.llms.fake import FakeListLLM
+
+
+def test_planner_returns_plan():
+    llm = FakeListLLM(responses=["plan"])
+    planner = WorkflowPlanner(llm=llm)
+    plan = planner.plan("reads", "assembly", "QC, assembly")
+    assert plan == "plan"


### PR DESCRIPTION
## Summary
- start `sunbeam.ai` package with workflow planner
- expose CLI at `sunbeam-ai`
- add optional dependencies for AI features
- test planner with a fake LLM

## Testing
- `pytest tests/unit -q`
- `pytest tests/unit/test_ai.py -q`
- `pytest -q` *(fails: conda command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de661d03c832380d6f876b5950157