### PR TITLE
Fix absolute paths in generated samples.csv

### DIFF
--- a/sunbeam/project/sample_list.py
+++ b/sunbeam/project/sample_list.py
@@ -68,7 +68,9 @@ class SampleList:
         logger.debug(f"Loading sample list from directory {fp}")
         samples = {}
         fnames = [
-            f for f in fp.iterdir() if f.is_file() and f.name.endswith(".fastq.gz")
+            f.resolve()
+            for f in fp.iterdir()
+            if f.is_file() and f.name.endswith(".fastq.gz")
         ]
         if len(fnames) == 0:
             raise ValueError("No gzipped FASTQ files found in the directory.")
@@ -161,9 +163,12 @@ class SampleList:
         with open(fp, "w") as f:
             writer = csv.DictWriter(f, delimiter=",", fieldnames=["sample", "r1", "r2"])
             for sample, data in self.samples.items():
-                row = {"sample": sample, "r1": data["r1"]}
+                row = {
+                    "sample": sample,
+                    "r1": str(Path(data["r1"]).resolve()),
+                }
                 if self.paired_end:
-                    row["r2"] = data["r2"]
+                    row["r2"] = str(Path(data["r2"]).resolve())
                 writer.writerow(row)
 
     def generate_subset(self, func: callable) -> "SampleList":

--- a/sunbeam/scripts/init.py
+++ b/sunbeam/scripts/init.py
@@ -32,7 +32,7 @@ def main(argv=sys.argv):
 
     data_fp = args.data_fp
     if data_fp:
-        data_fp = Path(data_fp)
+        data_fp = Path(data_fp).resolve()
         paired_end = not args.single_end
         sample_list = SampleList(data_fp, paired_end, args.format)
         sample_list.to_file(project_fp / "samples.csv")


### PR DESCRIPTION
## Summary
- ensure `sunbeam init` resolves provided data directory
- write absolute file paths when generating the samples.csv file
- resolve filenames when loading from directories so paths remain absolute

## Testing
- `ruff check sunbeam/scripts/init.py sunbeam/project/sample_list.py`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'sunbeam')*

------
https://chatgpt.com/codex/tasks/task_e_6887a6dba6f883238085d72790f72b0b