### PR TITLE
Handle ruleorder for single-end reads

### DIFF
--- a/sunbeam/workflow/rules/qc.smk
+++ b/sunbeam/workflow/rules/qc.smk
@@ -25,7 +25,13 @@ rule sample_intake:
         "../scripts/sample_intake.py"
 
 
-ruleorder: adapter_removal_paired > adapter_removal_unpaired
+if Cfg["all"]["paired_end"]:
+
+    ruleorder: adapter_removal_paired > adapter_removal_unpaired
+
+else:
+
+    ruleorder: adapter_removal_unpaired > adapter_removal_paired
 
 
 rule adapter_removal_unpaired:
@@ -73,7 +79,13 @@ rule adapter_removal_paired:
         "../scripts/adapter_removal_paired.py"
 
 
-ruleorder: trimmomatic_paired > trimmomatic_unpaired
+if Cfg["all"]["paired_end"]:
+
+    ruleorder: trimmomatic_paired > trimmomatic_unpaired
+
+else:
+
+    ruleorder: trimmomatic_unpaired > trimmomatic_paired
 
 
 # Check that the adapter template file exists


### PR DESCRIPTION
## Summary
- Use conditional rule order for adapter removal to prevent paired rule from executing on single-end data
- Apply same conditional ordering for trimmomatic rules

## Testing
- `snakefmt sunbeam/workflow/rules/qc.smk`
- `pytest tests/e2e/test_sunbeam_run.py::test_sunbeam_run_with_single_end_reads -q` *(fails: Conda environment creation blocked by proxy configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6894b9423a4883238dafc618275b6889