### PR TITLE
Default extensions path to home directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Dear Agents,
+
+This is a Python library wrapping a Snakemake pipeline for metagenomic bioinformatics.
+
+## Project Structure
+
+- `sunbeam/`
+  - `bfx/`: Helper bioinformatics functions
+  - `configs/`: Example and template config and profile files
+  - `project/`: Classes for managing Sunbeam specific config files
+  - `scripts/`: CLI commands
+  - `workflow/`: The Snakemake workflow definition
+- `extensions/`: This is where extensions are installed to (`git clone`d). This directory can also live elsewhere as defined by the `$SUNBEAM_EXTENSIONS` variable
+
+## Contribution Guidelines
+
+Before making contributions to the codebase:
+
+- Reformat the codebase with `black .`
+- Make sure unit tests pass with `pytest tests/unit/`
+  - If they aren't passing be sure to include an explanation why

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -33,7 +33,9 @@ The ``configs/`` directory contains sample configuration files for the pipeline.
 extensions
 ----------
 
-This is the default location for extensions, although it can be configured by setting ``$SUNBEAM_EXTENSIONS``.
+The source tree contains an ``extensions/`` directory with example extensions.
+At runtime Sunbeam loads extensions from the directory specified by
+``$SUNBEAM_EXTENSIONS``, which defaults to ``~/.sunbeam/extensions``.
 
 project
 -------

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -8,7 +8,10 @@ Sunbeam is designed to be extensible. You can install and run extensions from ou
 
 .. tip::
 
-    Extensions live in the ``extensions/`` directory under the Sunbeam root installation. You can also set the environment variable ``$SUNBEAM_EXTENSIONS`` to point to a different directory if you want to keep your extensions separate from the core Sunbeam installation.
+    By default Sunbeam looks for extensions in ``~/.sunbeam/extensions``. Set the
+    environment variable ``$SUNBEAM_EXTENSIONS`` to point to a different
+    directory if you want to keep your extensions separate from the core Sunbeam
+    installation.
 
 This is now going to pick up where :ref:`quickstart` left off and show how to install and run ``sbx_kraken`` for taxonomic classification of your QCed and decontaminated reads.
 

--- a/sunbeam/__init__.py
+++ b/sunbeam/__init__.py
@@ -8,9 +8,15 @@ __license__ = "GPL2+"
 logger = get_sunbeam_logger()
 
 
-EXTENSIONS_DIR = lambda: Path(
-    os.environ.get("SUNBEAM_EXTENSIONS", Path(__file__).parent.resolve() / "extensions")
-)
+# Directory where extensions are stored. This defaults to ``~/.sunbeam/extensions``
+# but can be overridden by setting the ``SUNBEAM_EXTENSIONS`` environment
+# variable.  The directory is created if it does not already exist so that
+# subsequent operations (such as cloning an extension) do not fail.
+def EXTENSIONS_DIR() -> Path:
+    default_dir = Path.home() / ".sunbeam" / "extensions"
+    ext_dir = Path(os.environ.get("SUNBEAM_EXTENSIONS", default_dir))
+    ext_dir.mkdir(parents=True, exist_ok=True)
+    return ext_dir
 WORKFLOW_DIR = Path(__file__).parent.resolve() / "workflow"
 CONFIGS_DIR = Path(__file__).parent.resolve() / "configs"
 

--- a/sunbeam/__init__.py
+++ b/sunbeam/__init__.py
@@ -17,6 +17,8 @@ def EXTENSIONS_DIR() -> Path:
     ext_dir = Path(os.environ.get("SUNBEAM_EXTENSIONS", default_dir))
     ext_dir.mkdir(parents=True, exist_ok=True)
     return ext_dir
+
+
 WORKFLOW_DIR = Path(__file__).parent.resolve() / "workflow"
 CONFIGS_DIR = Path(__file__).parent.resolve() / "configs"
 

--- a/sunbeam/bfx/decontam.py
+++ b/sunbeam/bfx/decontam.py
@@ -17,7 +17,7 @@ def get_mapped_reads(fp: str, min_pct_id: float, min_len_frac: float) -> Iterato
 
 
 def _get_pct_identity(
-    read: Dict[str, Union[int, float, str, Tuple[int, str]]]
+    read: Dict[str, Union[int, float, str, Tuple[int, str]]],
 ) -> float:
     edit_dist = read.get("NM", 0)
     pct_mm = float(edit_dist) / len(read["SEQ"])


### PR DESCRIPTION
## Summary
- default SUNBEAM_EXTENSIONS to `~/.sunbeam/extensions`
- create extension directory if missing
- document new default extension location

## Testing
- `pytest -q` *(fails: conda not installed, `sunbeam` CLI missing)*

------
https://chatgpt.com/codex/tasks/task_e_68acf4344b708323a56a48bdd540d0a8