### PR TITLE
Validate AI-generated rules with Snakemake

### DIFF
--- a/tests/unit/test_rule_validation.py
+++ b/tests/unit/test_rule_validation.py
@@ -1,0 +1,24 @@
+import pytest
+
+from sunbeam.ai.rule_creator import _snakemake_rules_validator
+
+
+def test_validator_accepts_valid_rules():
+    rules = (
+        "rule test:\n"
+        "    output: 'out.txt'\n"
+        "    shell:\n"
+        "        'echo hi > {output}'\n"
+    )
+    _snakemake_rules_validator(rules)
+
+
+def test_validator_rejects_invalid_rules():
+    bad_rules = (
+        "rule test\n"  # missing colon after rule name
+        "    output: 'out.txt'\n"
+        "    shell:\n"
+        "        'echo hi > {output}'\n"
+    )
+    with pytest.raises(ValueError):
+        _snakemake_rules_validator(bad_rules)


### PR DESCRIPTION
## Summary
- replace simple string checks with Snakemake-based rule validation
- add unit tests for rule validation

## Testing
- `black .`
- `pytest tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68b7292e22e483239644e19c10328612