### PR TITLE
Add preprocess report parsers and summary aggregation

### DIFF
--- a/sunbeam/workflow/scripts/preprocess_report.py
+++ b/sunbeam/workflow/scripts/preprocess_report.py
@@ -1,11 +1,259 @@
+import csv
+import json
+import math
 import traceback
-from typing import TextIO
+from typing import (
+    Dict,
+    Iterable as TypingIterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    TextIO,
+    Union,
+)
+
+
+Number = Union[int, float]
+
+
+def _ensure_list(value: Union[str, TypingIterable[str]]) -> List[str]:
+    """Return *value* as a list of paths."""
+
+    if isinstance(value, (list, tuple, set)):
+        return [str(v) for v in value]
+    return [str(value)]
+
+
+def parse_adapter_report(
+    report: Union[str, TypingIterable[str]],
+) -> Dict[str, Optional[Number]]:
+    """Parse adapter removal (fastp) JSON reports.
+
+    The fastp report already combines read 1 and read 2 for a sample. However,
+    the helper gracefully supports being passed multiple reports by summing the
+    count-based fields and computing weighted averages where appropriate.
+    """
+
+    totals: Dict[str, Optional[Number]] = {
+        "adapter_total_reads_before": 0,
+        "adapter_total_bases_before": 0,
+        "adapter_total_reads_after": 0,
+        "adapter_total_bases_after": 0,
+        "adapter_passed_filter_reads": 0,
+        "adapter_low_quality_reads": 0,
+        "adapter_too_many_N_reads": 0,
+        "adapter_low_complexity_reads": 0,
+        "adapter_too_short_reads": 0,
+        "adapter_too_long_reads": 0,
+        "adapter_duplication_rate": 0.0,
+        "adapter_read1_mean_length": 0.0,
+        "adapter_read2_mean_length": 0.0,
+        "adapter_gc_content_before": 0.0,
+        "adapter_gc_content_after": 0.0,
+    }
+
+    total_before_bases = 0.0
+    total_after_bases = 0.0
+
+    reports = _ensure_list(report)
+    if not reports:
+        return totals
+
+    for path in reports:
+        with open(path) as fh:
+            data = json.load(fh)
+
+        summary = data.get("summary", {})
+        before = summary.get("before_filtering", {})
+        after = summary.get("after_filtering", {})
+        duplication = data.get("duplication", {})
+        filtering_result = data.get("filtering_result", {})
+
+        totals["adapter_total_reads_before"] += before.get("total_reads", 0)
+        totals["adapter_total_bases_before"] += before.get("total_bases", 0)
+        totals["adapter_total_reads_after"] += after.get("total_reads", 0)
+        totals["adapter_total_bases_after"] += after.get("total_bases", 0)
+
+        totals["adapter_passed_filter_reads"] += filtering_result.get(
+            "passed_filter_reads", 0
+        )
+        totals["adapter_low_quality_reads"] += filtering_result.get(
+            "low_quality_reads", 0
+        )
+        totals["adapter_too_many_N_reads"] += filtering_result.get(
+            "too_many_N_reads", 0
+        )
+        totals["adapter_low_complexity_reads"] += filtering_result.get(
+            "low_complexity_reads", 0
+        )
+        totals["adapter_too_short_reads"] += filtering_result.get("too_short_reads", 0)
+        totals["adapter_too_long_reads"] += filtering_result.get("too_long_reads", 0)
+
+        duplication_rate = duplication.get("rate")
+        if duplication_rate is not None:
+            totals["adapter_duplication_rate"] += duplication_rate
+
+        for key, field in (
+            ("adapter_read1_mean_length", "read1_mean_length"),
+            ("adapter_read2_mean_length", "read2_mean_length"),
+        ):
+            value = after.get(field)
+            if value is not None:
+                totals[key] = (totals[key] or 0.0) + value
+
+        before_gc = before.get("gc_content")
+        if before_gc is not None:
+            total_before_bases += before.get("total_bases", 0) * before_gc
+        after_gc = after.get("gc_content")
+        if after_gc is not None:
+            total_after_bases += after.get("total_bases", 0) * after_gc
+
+    num_reports = len(reports)
+    if num_reports > 0:
+        if totals["adapter_duplication_rate"] is not None:
+            totals["adapter_duplication_rate"] /= num_reports
+
+        for key in ("adapter_read1_mean_length", "adapter_read2_mean_length"):
+            if totals[key] is not None:
+                totals[key] /= num_reports
+
+    before_bases = totals["adapter_total_bases_before"]
+    totals["adapter_gc_content_before"] = (
+        total_before_bases / before_bases if before_bases else 0.0
+    )
+
+    after_bases = totals["adapter_total_bases_after"]
+    totals["adapter_gc_content_after"] = (
+        total_after_bases / after_bases if after_bases else 0.0
+    )
+
+    return totals
+
+
+def _parse_read_count_line(line: str) -> Optional[Dict[str, Number]]:
+    line = line.strip()
+    if not line:
+        return None
+
+    # Example: "Input reads: total=4000, average_length=70.00"
+    if not line.startswith(("Input reads", "Output reads")):
+        return None
+
+    _, payload = line.split(":", 1)
+    parts = payload.strip().split(",")
+    values: Dict[str, Number] = {}
+    for part in parts:
+        if "=" not in part:
+            continue
+        key, value = part.strip().split("=", 1)
+        if key == "total":
+            values[key] = int(value)
+        elif key == "average_length":
+            values[key] = float(value)
+    return values if values else None
+
+
+def _aggregate_read_count_reports(
+    report: Union[str, TypingIterable[str]], prefix: str
+) -> Dict[str, Optional[Number]]:
+    totals = {
+        f"{prefix}_input_reads": 0,
+        f"{prefix}_output_reads": 0,
+        f"{prefix}_input_average_length": math.nan,
+        f"{prefix}_output_average_length": math.nan,
+    }
+
+    input_bases = 0.0
+    output_bases = 0.0
+
+    for path in _ensure_list(report):
+        with open(path) as fh:
+            for line in fh:
+                parsed = _parse_read_count_line(line)
+                if not parsed:
+                    continue
+                if line.startswith("Input reads"):
+                    totals[f"{prefix}_input_reads"] += int(parsed.get("total", 0))
+                    input_bases += parsed.get("total", 0) * parsed.get(
+                        "average_length", 0.0
+                    )
+                elif line.startswith("Output reads"):
+                    totals[f"{prefix}_output_reads"] += int(parsed.get("total", 0))
+                    output_bases += parsed.get("total", 0) * parsed.get(
+                        "average_length", 0.0
+                    )
+
+    if totals[f"{prefix}_input_reads"]:
+        totals[f"{prefix}_input_average_length"] = (
+            input_bases / totals[f"{prefix}_input_reads"]
+        )
+    if totals[f"{prefix}_output_reads"]:
+        totals[f"{prefix}_output_average_length"] = (
+            output_bases / totals[f"{prefix}_output_reads"]
+        )
+
+    return totals
+
+
+def parse_quality_report(
+    report: Union[str, TypingIterable[str]],
+) -> Dict[str, Optional[Number]]:
+    return _aggregate_read_count_reports(report, "quality")
+
+
+def parse_complexity_report(
+    report: Union[str, TypingIterable[str]],
+) -> Dict[str, Optional[Number]]:
+    return _aggregate_read_count_reports(report, "complexity")
+
+
+def parse_decontam_report(
+    report: Union[str, TypingIterable[str]],
+) -> Dict[str, Optional[Number]]:
+    totals: MutableMapping[str, Number] = {}
+    for path in _ensure_list(report):
+        with open(path, newline="") as fh:
+            reader = csv.DictReader(fh, delimiter="\t")
+            for row in reader:
+                for key, value in row.items():
+                    try:
+                        numeric_value: Number = int(value)
+                    except (TypeError, ValueError):
+                        try:
+                            numeric_value = float(value)
+                        except (TypeError, ValueError):
+                            continue
+                    totals[f"decontam_{key}"] = (
+                        totals.get(f"decontam_{key}", 0) + numeric_value
+                    )
+
+    return dict(totals)
+
+
+def parse_reports(reports: Mapping[str, Mapping[str, Union[str, TypingIterable[str]]]]):
+    import pandas
+
+    rows = []
+    for sample, paths in sorted(reports.items()):
+        row: Dict[str, Optional[Number]] = {"sample": sample}
+
+        adapter_data = parse_adapter_report(paths["adapter"])
+        quality_data = parse_quality_report(paths["trim"])
+        complexity_data = parse_complexity_report(paths["complexity"])
+        decontam_data = parse_decontam_report(paths["decontam"])
+
+        row.update(adapter_data)
+        row.update(quality_data)
+        row.update(complexity_data)
+        row.update(decontam_data)
+        rows.append(row)
+
+    df = pandas.DataFrame(rows).set_index("sample")
+    return df.sort_index()
 
 
 def f(log: TextIO):
-    import pandas
-    from sunbeam.bfx.reports import summarize_qual_decontam
-
     adapter_reports = snakemake.input.adapter  # type: ignore
     trim_reports = snakemake.input.trim  # type: ignore
     complexity_reports = snakemake.input.complexity  # type: ignore
@@ -21,26 +269,23 @@ def f(log: TextIO):
     }
     log.write(f"Reports: {reports}\n")
 
-    summary_list = [
-        summarize_qual_decontam(q, d, k, paired_end)
-        for q, d, k in zip(
-            snakemake.input.trim_files,
-            snakemake.input.decontam_files,
-            snakemake.input.komplexity_files,
-        )
-    ]
-    _reports = pandas.concat(summary_list)
-    _reports.to_csv(snakemake.output[0], sep="\t", index_label="Samples")
+    df = parse_reports(reports)
+    df.to_csv(output_report, sep="\t", index_label="sample")
 
 
-log_f = snakemake.log[0]  # type: ignore
-with open(log_f, "w") as log:
-    log.write("Initialized log and starting script...\n")
-    try:
-        f(log)
-    except BaseException as e:
-        log.write(f"Error during run: {e}\n")
-        log.write(traceback.format_exc())
-        raise
-    else:
-        log.write("Completed successfully.\n")
+def run_from_snakemake():  # pragma: no cover - executed within snakemake
+    log_f = snakemake.log[0]  # type: ignore
+    with open(log_f, "w") as log:
+        log.write("Initialized log and starting script...\n")
+        try:
+            f(log)
+        except BaseException as e:
+            log.write(f"Error during run: {e}\n")
+            log.write(traceback.format_exc())
+            raise
+        else:
+            log.write("Completed successfully.\n")
+
+
+if "snakemake" in globals():  # pragma: no cover - executed within snakemake
+    run_from_snakemake()

--- a/tests/unit/test_preprocess_report.py
+++ b/tests/unit/test_preprocess_report.py
@@ -1,0 +1,140 @@
+import json
+from pathlib import Path
+
+import pandas
+import pytest
+
+from sunbeam.workflow.scripts.preprocess_report import (
+    parse_adapter_report,
+    parse_complexity_report,
+    parse_decontam_report,
+    parse_quality_report,
+    parse_reports,
+)
+
+
+ADAPTER_EXAMPLE = {
+    "summary": {
+        "fastp_version": "0.22.0",
+        "sequencing": "paired end (70 cycles + 70 cycles)",
+        "before_filtering": {
+            "total_reads": 4000,
+            "total_bases": 280000,
+            "q20_bases": 0,
+            "q30_bases": 0,
+            "q20_rate": 0,
+            "q30_rate": 0,
+            "read1_mean_length": 70,
+            "read2_mean_length": 70,
+            "gc_content": 0.487557,
+        },
+        "after_filtering": {
+            "total_reads": 4000,
+            "total_bases": 280000,
+            "q20_bases": 0,
+            "q30_bases": 0,
+            "q20_rate": 0,
+            "q30_rate": 0,
+            "read1_mean_length": 70,
+            "read2_mean_length": 70,
+            "gc_content": 0.487557,
+        },
+    },
+    "filtering_result": {
+        "passed_filter_reads": 4000,
+        "low_quality_reads": 0,
+        "too_many_N_reads": 0,
+        "low_complexity_reads": 0,
+        "too_short_reads": 0,
+        "too_long_reads": 0,
+    },
+    "duplication": {"rate": 0},
+}
+
+
+QUALITY_EXAMPLE = """Input reads: total=4000, average_length=70.00\nOutput reads: total=4000, average_length=70.00\n"""
+
+COMPLEXITY_EXAMPLE = """Input reads: total=4000, average_length=70.00\nOutput reads: total=3990, average_length=70.00\n"""
+
+DECONTAM_EXAMPLE = "human\thuman_copy\tphix174\thost\tnonhost\n0\t0\t0\t0\t1995\n"
+
+
+def write_file(path: Path, contents: str) -> str:
+    path.write_text(contents)
+    return str(path)
+
+
+def write_json(path: Path, payload) -> str:
+    path.write_text(json.dumps(payload))
+    return str(path)
+
+
+def test_parse_adapter_report(tmp_path):
+    report_path = write_json(tmp_path / "adapter.json", ADAPTER_EXAMPLE)
+    parsed = parse_adapter_report(report_path)
+
+    assert parsed["adapter_total_reads_before"] == 4000
+    assert parsed["adapter_total_reads_after"] == 4000
+    assert parsed["adapter_total_bases_before"] == 280000
+    assert parsed["adapter_total_bases_after"] == 280000
+    assert parsed["adapter_passed_filter_reads"] == 4000
+    assert parsed["adapter_gc_content_before"] == pytest.approx(0.487557)
+    assert parsed["adapter_gc_content_after"] == pytest.approx(0.487557)
+    assert parsed["adapter_read1_mean_length"] == pytest.approx(70)
+    assert parsed["adapter_read2_mean_length"] == pytest.approx(70)
+
+
+def test_parse_quality_report(tmp_path):
+    report_path = write_file(tmp_path / "quality.txt", QUALITY_EXAMPLE)
+    parsed = parse_quality_report(report_path)
+
+    assert parsed["quality_input_reads"] == 4000
+    assert parsed["quality_output_reads"] == 4000
+    assert parsed["quality_input_average_length"] == pytest.approx(70)
+    assert parsed["quality_output_average_length"] == pytest.approx(70)
+
+
+def test_parse_complexity_report(tmp_path):
+    report_path = write_file(tmp_path / "complexity.txt", COMPLEXITY_EXAMPLE)
+    parsed = parse_complexity_report(report_path)
+
+    assert parsed["complexity_input_reads"] == 4000
+    assert parsed["complexity_output_reads"] == 3990
+
+
+def test_parse_decontam_report(tmp_path):
+    report_path = write_file(tmp_path / "decontam.txt", DECONTAM_EXAMPLE)
+    parsed = parse_decontam_report(report_path)
+
+    assert parsed == {
+        "decontam_human": 0,
+        "decontam_human_copy": 0,
+        "decontam_phix174": 0,
+        "decontam_host": 0,
+        "decontam_nonhost": 1995,
+    }
+
+
+def test_parse_reports_integration(tmp_path):
+    adapter = write_json(tmp_path / "adapter.json", ADAPTER_EXAMPLE)
+    quality = write_file(tmp_path / "quality.txt", QUALITY_EXAMPLE)
+    complexity = write_file(tmp_path / "complexity.txt", COMPLEXITY_EXAMPLE)
+    decontam = write_file(tmp_path / "decontam.txt", DECONTAM_EXAMPLE)
+
+    df = parse_reports(
+        {
+            "sample1": {
+                "adapter": adapter,
+                "trim": quality,
+                "complexity": complexity,
+                "decontam": decontam,
+            }
+        }
+    )
+
+    assert isinstance(df, pandas.DataFrame)
+    assert list(df.index) == ["sample1"]
+    assert df.loc["sample1", "adapter_total_reads_before"] == 4000
+    assert df.loc["sample1", "quality_output_reads"] == 4000
+    assert df.loc["sample1", "complexity_output_reads"] == 3990
+    assert df.loc["sample1", "decontam_nonhost"] == 1995


### PR DESCRIPTION
## Summary
- implement parsing helpers for adapter, quality, complexity, and decontam reports and generate the combined TSV output
- support multiple report files per sample and guard the snakemake entrypoint
- add unit tests covering the new parsers and integration

## Testing
- pytest tests/unit

------
https://chatgpt.com/codex/tasks/task_e_68e548d0d8d4832380e217c3ddf5ec8f