### PR TITLE
Ensure sunbeam run -h displays subcommand help

### DIFF
--- a/sunbeam/scripts/sunbeam.py
+++ b/sunbeam/scripts/sunbeam.py
@@ -12,6 +12,12 @@ def main():
     parser = main_parser()
     args, remaining = parser.parse_known_args()
 
+    # If no subcommand was provided, fall back to displaying the top-level help
+    # when explicitly requested.
+    if args.command is None and any(opt in remaining for opt in ("-h", "--help")):
+        parser.print_help()
+        return
+
     if args.command == "run":
         Run(remaining)
     elif args.command == "init":
@@ -47,11 +53,4 @@ def main_parser():
         action="version",
         version=__version__,
     )
-    parser.add_argument(
-        "-h",
-        "--help",
-        action="help",
-        help="Show this help message and exit.",
-    )
-
     return parser


### PR DESCRIPTION
## Summary
- prevent the top-level CLI parser from consuming subcommand help flags
- allow `sunbeam run -h` to print the run-specific help text

## Testing
- pytest tests/unit/


------
https://chatgpt.com/codex/tasks/task_e_68ee706f24248323b6fd1942864d1e02